### PR TITLE
Quickcheck: model for 3 type of crashes plus clustering

### DIFF
--- a/test/grisp_gpio_drv_emu.erl
+++ b/test/grisp_gpio_drv_emu.erl
@@ -9,18 +9,18 @@
 
 open() -> undefined.
 
-command(_State, <<8, 3>>)  -> led(1, red, off);
-command(_State, <<8, 4>>)  -> led(1, red, on);
-command(_State, <<9, 3>>)  -> led(1, green, off);
-command(_State, <<9, 4>>)  -> led(1, green, on);
-command(_State, <<10, 3>>) -> led(1, blue, off);
-command(_State, <<10, 4>>) -> led(1, blue, on);
-command(_State, <<11, 3>>) -> led(2, red, off);
-command(_State, <<11, 4>>) -> led(2, red, on);
-command(_State, <<12, 3>>) -> led(2, green, off);
-command(_State, <<12, 4>>) -> led(2, green, on);
-command(_State, <<13, 3>>) -> led(2, blue, off);
-command(_State, <<13, 4>>) -> led(2, blue, on);
+command(_State, <<8, 3>>)  -> ok = led(1, red, off);
+command(_State, <<8, 4>>)  -> ok = led(1, red, on);
+command(_State, <<9, 3>>)  -> ok = led(1, green, off);
+command(_State, <<9, 4>>)  -> ok = led(1, green, on);
+command(_State, <<10, 3>>) -> ok = led(1, blue, off);
+command(_State, <<10, 4>>) -> ok = led(1, blue, on);
+command(_State, <<11, 3>>) -> ok = led(2, red, off);
+command(_State, <<11, 4>>) -> ok = led(2, red, on);
+command(_State, <<12, 3>>) -> ok = led(2, green, off);
+command(_State, <<12, 4>>) -> ok = led(2, green, on);
+command(_State, <<13, 3>>) -> ok = led(2, blue, off);
+command(_State, <<13, 4>>) -> ok = led(2, blue, on);
 command(_State, Command) ->
     grisp_device_emu:broadcast({gpio, Command}).
 

--- a/test/led_eqc.erl
+++ b/test/led_eqc.erl
@@ -23,14 +23,14 @@
 %% -- Generators -------------------------------------------------------------
 
 color() ->
-  oneof([ {black,   {0, 0, 0}},
-          {blue,    {0, 0, 1}},
-          {green,   {0, 1, 0}},
-          {aqua,    {0, 1, 1}},
-          {red,     {1, 0, 0}},
-          {magenta, {1, 0, 1}},
-          {yellow,  {1, 1, 0}},
-          {white,   {1, 1, 1}}]).
+  elements([ {black,   {0, 0, 0}},
+             {blue,    {0, 0, 1}},
+             {green,   {0, 1, 0}},
+             {red,     {1, 0, 0}},
+             {aqua,    {0, 1, 1}},
+             {magenta, {1, 0, 1}},
+             {yellow,  {1, 1, 0}},
+             {white,   {1, 1, 1}}]).
 
 %% -- State ------------------------------------------------------------------
 initial_state() ->
@@ -41,30 +41,28 @@ postcondition_common(S, Call, Res) ->
 
 %% -- Operations -------------------------------------------------------------
 
-%% --- Operation: grisp_led ---
-grisp_led_args(_S) ->
+%% --- Operation: led_color ---
+led_color_args(_S) ->
   [choose(1, ?NR_LEDS), color(), elements([by_value, by_name])].
 
-grisp_led(Nr, {Name, _RGB}, by_name) ->
+led_color(Nr, {Name, _RGB}, by_name) ->
   grisp_led:color(Nr, Name),
   timer:sleep(10);
-grisp_led(Nr, {_Name, RGB}, by_value) ->
+led_color(Nr, {_Name, RGB}, by_value) ->
   grisp_led:color(Nr, RGB),
   timer:sleep(10).
 
-grisp_led_callouts(_S, [Nr, {_, {R, G, B}}, _]) ->
+led_color_callouts(_S, [Nr, {_, {R, G, B}}, _]) ->
   ?PAR([
-        ?CALLOUT(grisp_gpio_drv_emu, led, [Nr, red, onoff(R)], ok),
+        ?CALLOUT(grisp_gpio_drv_emu, led, [Nr, red,   onoff(R)], ok),
         ?CALLOUT(grisp_gpio_drv_emu, led, [Nr, green, onoff(G)], ok),
-        ?CALLOUT(grisp_gpio_drv_emu, led, [Nr, blue, onoff(B)], ok)]),
+        ?CALLOUT(grisp_gpio_drv_emu, led, [Nr, blue,  onoff(B)], ok)]),
+  ?RET(ok).
   ?RET(ok).
 
 
 onoff(1) -> on;
 onoff(0) -> off.
-  
-%% borrowed code, ugly!
-
 
 
 %% -- Property ---------------------------------------------------------------
@@ -83,6 +81,7 @@ prop_led() ->
                  eqc_cover:write_html(eqc_cover:stop(), [{out_dir, "cover"}])
              end %% Teardown function
          end,
+  eqc:dont_print_counterexample(
   ?FORALL(Cmds, commands(?MODULE),
   begin
     {H, S, Res} = run_commands(Cmds),
@@ -90,7 +89,7 @@ prop_led() ->
                         measure(length, commands_length(Cmds),
                                 pretty_commands(?MODULE, Cmds, {H, S, Res},
                                                 Res == ok)))
-  end)).
+  end))).
 
 %% -- API-spec ---------------------------------------------------------------
 api_spec() -> 

--- a/test/let_it_crash_eqc.erl
+++ b/test/let_it_crash_eqc.erl
@@ -35,7 +35,7 @@ initial_state(N, Period) ->
 
 %% -- helpers ----------------------------------------------------------------
 
-%% 0 is not allowed, otherwise value returned is moment of crash
+%% 0 equals not allowed, other value returned is moment of crash
 crashing_allowed(Crashes, Period, Max) ->
   Now = dynamic_now(),
   InPeriod = [ Crash || Crash <- Crashes, Crash > (Now - (Period + ?MARGIN)) ],
@@ -73,6 +73,7 @@ crash(Processes, N, Crashes, Period, Max) ->
       end
   end.
 
+%% Only for failure output to see which process has been killed
 crash_callouts(_S, _Args) ->
   ?OPTIONAL(?CALLOUT(let_it_crash, process, [?WILDCARD], ok)).
 
@@ -99,7 +100,7 @@ driver_failure_args(S) ->
          [choose(1,3), S#state.crashes, S#state.period, S#state.max_crashes]).
 
 driver_failure_pre(S, [_, _, _, _Failure, Crashes, _, _]) ->
-  S#state.crashes == Crashes andalso S#state.crashes =/= [].
+  S#state.crashes == Crashes.
 
 driver_failure_adapt(S, [Nr, Color, Kind, Failure, _Crashes, Period, Max]) ->
   [Nr, Color, Kind, Failure, S#state.crashes, Period, Max].

--- a/test/let_it_crash_eqc.erl
+++ b/test/let_it_crash_eqc.erl
@@ -1,0 +1,139 @@
+%%% @author Thomas Arts 
+%%% @copyright (C) 2017, Thomas Arts
+%%% @doc A specific component that should be clustered using with_crashes_eqc.erl
+%%%      with a general component specification that has a supervisor structure
+%%%      to restart processes.
+%%%
+%%%      We test that any N crashes in T seconds can be tolerated.
+%%%
+%%% @end
+%%% Created : 23 Jul 2017 by Thomas Arts
+
+-module(let_it_crash_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_component.hrl").
+
+-compile(export_all).
+
+-define(IFF(X,Y), (not(X) orelse Y) andalso (not(Y) orelse X)).
+
+%% -- State ------------------------------------------------------------------
+-record(state,{crashes = [],  %% [ time() ]
+               max_crashes,
+               period
+              }).
+
+initial_state() ->
+  initial_state(2,1).
+
+initial_state(N, Period) ->
+  #state{max_crashes = N, period = Period * 1000}.
+
+
+%% -- helpers ----------------------------------------------------------------
+
+%% 0 is not allowed, otherwise value returned is moment of crash
+crashing_allowed(Crashes, Period, Max) ->
+  Now = dynamic_now(),
+  InPeriod = [ Crash || Crash <- Crashes, Crash > (Now - Period) ],
+  if length(InPeriod) < Max -> Now; true -> 0 end.
+
+%% --- Operation: crash ---
+crash_args(S) ->
+   [ {var, base_processes}, nat(), S#state.crashes, S#state.period, S#state.max_crashes ].
+
+crash_pre(S, [_, _, Crashes, _, _]) ->
+  S#state.crashes == Crashes.
+
+crash_adapt(S, [Var, N, _Crashes, Period, Max]) ->
+  [Var, N, S#state.crashes, Period, Max].
+
+crash(Processes, N, Crashes, Period, Max) ->
+  NewProcs = erlang:processes() -- Processes,
+  case erlang:processes() -- Processes of
+    [] ->
+      0;  %% no new processes created, we cannot crash anything
+    _ ->
+      Proc = lists:nth((N rem length(NewProcs)) + 1, NewProcs),
+      case crashing_allowed(Crashes, Period, Max) of
+        0 ->
+          %% Zero is always outside the period that we look at
+          0;
+        Now ->
+          io:format("Crashing proc ~p: ~p from total ~p\n",[Proc, (N rem length(NewProcs)) + 1, length(NewProcs) ]),
+          Info = erlang:process_info(Proc),
+          timer:exit_after(7, Proc, killed_by_quickcheck),
+                                                % exit(Proc, killed_by_quickcheck),
+          let_it_crash:process(Info),
+          Now
+      end
+  end.
+
+crash_callouts(_S, _Args) ->
+  ?OPTIONAL(?CALLOUT(let_it_crash, process, [?WILDCARD], ok)).
+
+crash_next(S, V, _Args) ->
+  S#state{crashes = S#state.crashes ++ [ V ]}.
+
+crash_features(S, _Args, Res) ->
+  [{crashed, length(S#state.crashes) + 1} || Res =/= 0].
+
+%% --- Operation: sleep ---
+sleep_pre(S) ->
+  length(S#state.crashes) > 0.
+
+sleep_args(S) ->
+  [?LET(T, choose(10, S#state.period), S#state.period - T)].
+
+sleep(Time) ->
+  timer:sleep(Time).
+
+
+
+
+
+%% -- Exception raising operations -------------------------------------------
+%% led_fault_tolerant_args(S) ->
+%%   [choose(1, 2), {brown, {2,1,0}} elements([byname, by_value]), 
+%%    S#state.crashes, S#state.period, S#state.max_crashes].
+
+led_fault_tolerant_pre(S, [_, _, _, Crashes, _, _]) ->
+  S#state.crashes == Crashes.
+
+led_fault_tolerant_adapt(S, [Nr, Color, NameVal, _Crashes, Period, Max]) ->
+  [Nr, Color, NameVal, S#state.crashes, Period, Max].
+
+led_fault_tolerant(Nr, Color, NameVal, Crashes, Period, Max) ->
+  case crashing_allowed(Crashes, Period, Max) of
+    0 ->
+      %% Zero is always outside the period that we look at
+      0;
+    Now ->
+      led_eqc:led_color(Nr, Color, NameVal),
+      Now
+  end.
+
+led_fault_tolerant_next(S, V, _) ->
+  S#state{crashes = S#state.crashes ++ [ V ]}.
+
+
+%% Now in milli seconds
+dynamic_now() ->
+  {Mega, S, Micro} = os:timestamp(),
+  ((Mega * 1000 * 1000 + S) * 1000) + (Micro div 1000)  .
+
+%% -- Property ---------------------------------------------------------------
+
+weight(_S, _Cmd) -> 1.
+
+api_spec() -> 
+  #api_spec{ language = erlang, 
+             mocking = eqc_mocking, 
+             modules = 
+               [  #api_module{ 
+                     name = let_it_crash, 
+                     functions = 
+                       [#api_fun{ name = process, arity = 1}] } ]}.
+
+

--- a/test/with_crashes_eqc.erl
+++ b/test/with_crashes_eqc.erl
@@ -1,0 +1,48 @@
+%%% @author Thomas Arts 
+%%% @copyright (C) 2017, Thomas Arts
+%%% @doc
+%%%
+%%% @end
+%%% Created : 23 Jul 2017 by Thomas Arts 
+
+-module(with_crashes_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_cluster.hrl").
+
+-compile(export_all).
+
+components() -> [ let_it_crash_eqc, led_eqc ].
+
+weight(let_it_crash_eqc) -> 1;
+weight(_) -> 5.
+
+api_spec() -> eqc_cluster:api_spec(?MODULE).
+
+prop_with_crashes(N, Period) ->
+  ?SETUP(fun() ->
+             %% setup mocking here
+             eqc_mocking:start_mocking(api_spec(), components()),
+             fun() ->  
+                 eqc_mocking:stop_mocking(),
+                 ok 
+             end %% Teardown function
+         end,
+  ?LET(Shrinking, parameter(shrinking, false),
+  ?FORALL(Cmds, commands(?MODULE, [ {let_it_crash_eqc, 
+                                     let_it_crash_eqc:initial_state(N,Period)} ]),
+  ?ALWAYS(if Shrinking -> 10; true -> 1 end,
+    begin
+      application:stop(grisp),
+      timer:sleep(10),
+      Processes = erlang:processes(),
+      ok = application:start(grisp),
+      timer:sleep(10),  
+      
+      {H, S, Res} = run_commands(Cmds, [{base_processes, Processes}]),
+      pretty_commands(?MODULE, Cmds, {H, S, Res},
+                      measure(length, length(Cmds),
+                              aggregate(call_features(H),
+                                        aggregate(command_names(Cmds),
+                                                  Res == ok))))
+    end)))).


### PR DESCRIPTION
The grisp application has a supervisor structure. Whenever a process crashes, some automatic restarting must recover the application.

In grisp_sup.erl the restart strategy is defined, but how to test that this indeed works as expected.
This QuickCheck model solves that, by adding fault injection in the form of:

1.  Random process crashes
2. Provoking user defined exceptions (e.g. turning on a `brown`led will raise an exception)
3. Provoking driver failures, i.e., the driver crashes randomly.

We found that the last kind of fault injection results in the complete application to stop and not restart. This QuickCheck model helps to provoke that behaviour.

```erlang
eqc:quickcheck(with_crashes_eqc:prop_with_crashes(1, 5)).
```
Verifies that if the application crashes once every 5 seconds, then automatic restarting keeps it alive.

The  "let_it_crash" model is by no means easy and could better have been designed as a Meta model, but since that technology is not yet widely available, this is a good work around.