### PR TITLE
Make onewire driver concurrency safe

### DIFF
--- a/src/grisp_onewire.erl
+++ b/src/grisp_onewire.erl
@@ -1,121 +1,164 @@
 -module(grisp_onewire).
+% Chip: DS2482-100 Single-Channel 1-Wire Master
+% https://datasheets.maximintegrated.com/en/ds/DS2482-100.pdf
 
-%% Chip: DS2482 - 1-Wire Master
-%% specification can be found at maximintegrated.com
+-behaviour(gen_server).
+
+% API
+-export([
+    start_link/0,
+    transaction/1,
+    reset/0,
+    write_config/1,
+    detect/0,
+    bus_reset/0,
+    write_byte/1,
+    write_triplet/1,
+    read_byte/0,
+    search/0
+]).
+
+% Callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
 
 -include("grisp_i2c.hrl").
 
-% API
--export([reset/0, write_config/1, detect/0, bus_reset/0,
-	 write_byte/1, write_triplet/1, read_byte/0, search/0]).
+-define(DS2482_I2C_ADR, 16#18).
+-define(CMD_DRST, 16#f0).
+-define(CMD_WCFG, 16#d2).
+-define(CMD_1WRS, 16#b4).
+-define(CMD_1WWB, 16#a5).
+-define(CMD_1WRB, 16#96).
+-define(CMD_1WT,  16#78).
+-define(CMD_SRP,  16#e1).
 
--define(ds2482_i2c_adr, 16#18).
--define(cmd_drst, 16#f0).
--define(cmd_wcfg, 16#d2).
--define(cmd_1wrs, 16#b4).
--define(cmd_1wwb, 16#a5).
--define(cmd_1wrb, 16#96).
--define(cmd_1wt,  16#78).
--define(cmd_srp,  16#e1).
-
--define(poll_interval, 10).
--define(poll_timeout, 1000).
+-define(TRANSACTION_KEY, '$onewire_transaction_token').
+-define(TRANSACTION_TOKEN, 4435846174457203). % Random token
 
 %--- API -----------------------------------------------------------------------
 
+% @private
+start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+transaction(Fun) when is_function(Fun) ->
+    case gen_server:call(?MODULE, {transaction, Fun}) of
+        {result, Result} ->
+            Result;
+        {exception, Class, Reason, Stacktrace} ->
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
 
 %% Spec: | S | AD,0 ‖ A ‖ DRST ‖ A ‖ Sr | AD,1 ‖ A | <byte> ‖ A\ | P |
 reset() ->
-    <<Status:8>> = grisp_i2c:msgs([?ds2482_i2c_adr, 
-				   {write, <<?cmd_drst>>}, 
-				   {read, 1, ?I2C_M_NO_RD_ACK}]),
+    assert_transaction(),
+    <<Status:8>> = grisp_i2c:msgs([?DS2482_I2C_ADR,
+                                   {write, <<?CMD_DRST>>},
+                                   {read, 1, ?I2C_M_NO_RD_ACK}]),
     case Status band 16#f7 of
-	16#10 -> ok;
-	Any -> error({invalid_status, Any})
+        16#10 -> ok;
+        Any -> error({invalid_status, Any})
     end.
 
 %% Spec: | S | AD,0 ‖ A ‖ WCFG ‖ A ‖ <byte> ‖ A ‖ Sr | AD,1 ‖ A | <byte> ‖ A\ | P |
 write_config(Conf) when is_list(Conf) ->
     write_config(lists:foldl(fun(X, A) -> A bor map_config(X) end, 0, Conf));
 write_config(Conf) when is_integer(Conf) ->
+    assert_transaction(),
     Val = (bnot(Conf) bsl 4) bor Conf,
-    case grisp_i2c:msgs([?ds2482_i2c_adr, 
-			 {write, <<?cmd_wcfg, Val>>},
-			 {read, 1, ?I2C_M_NO_RD_ACK}]) of
-	<<Conf:8>> ->
-	    ok;
-	Any -> error({read_back_config, Any, Val})
+    case grisp_i2c:msgs([?DS2482_I2C_ADR,
+                         {write, <<?CMD_WCFG, Val>>},
+                         {read, 1, ?I2C_M_NO_RD_ACK}]) of
+        <<Conf:8>> ->
+            ok;
+        Any -> error({read_back_config, Any, Val})
     end.
 
-map_config(apu) ->
-    1;
-map_config(spu) ->
-    4;
-map_config(overdrive) ->
-    8.
-
 detect() ->
+    assert_transaction(),
     reset(),
     write_config([apu]).
 
 bus_reset() ->
-    grisp_i2c:msgs([?ds2482_i2c_adr, {write, <<?cmd_1wrs>>}]),
+    assert_transaction(),
+    grisp_i2c:msgs([?DS2482_I2C_ADR, {write, <<?CMD_1WRS>>}]),
     timer:sleep(1),
-    check_status(grisp_i2c:msgs([?ds2482_i2c_adr, 
-				 {read, 1, ?I2C_M_NO_RD_ACK}])).
-
-check_status(<<_:5, Sd:1, Ppd:1, 0:1>>) ->
-    case {Sd, Ppd} of
-	{0, 0} -> nothing_present;
-	{0, 1} -> presence_detected;
-	{1, _} -> short_detected
-    end;
-check_status(<<_:7, 1:1>>) ->
-    error(bus_reset_busy).
+    check_status(grisp_i2c:msgs([?DS2482_I2C_ADR,
+                                 {read, 1, ?I2C_M_NO_RD_ACK}])).
 
 write_byte(Byte) ->
-    grisp_i2c:msgs([?ds2482_i2c_adr, {write, <<?cmd_1wwb, Byte>>}]),
+    assert_transaction(),
+    grisp_i2c:msgs([?DS2482_I2C_ADR, {write, <<?CMD_1WWB, Byte>>}]),
     timer:sleep(1).
 
 read_byte() ->
-    grisp_i2c:msgs([?ds2482_i2c_adr, 
-		    {write, <<?cmd_1wrb>>}]),
+    assert_transaction(),
+    grisp_i2c:msgs([?DS2482_I2C_ADR,
+                    {write, <<?CMD_1WRB>>}]),
     timer:sleep(1),
-    grisp_i2c:msgs([?ds2482_i2c_adr, 
-		    {write, <<?cmd_srp, 16#e1>>},
-		    {read, 1, ?I2C_M_NO_RD_ACK}]).
+    grisp_i2c:msgs([?DS2482_I2C_ADR,
+                    {write, <<?CMD_SRP, 16#e1>>},
+                    {read, 1, ?I2C_M_NO_RD_ACK}]).
 
 write_triplet(Dir) ->
-    grisp_i2c:msgs([?ds2482_i2c_adr, {write, <<?cmd_1wt, Dir>>}]),
+    assert_transaction(),
+    grisp_i2c:msgs([?DS2482_I2C_ADR, {write, <<?CMD_1WT, Dir>>}]),
     timer:sleep(1),
-    <<D:1, T:1, S:1, _:5>> = grisp_i2c:msgs([?ds2482_i2c_adr, 
-					     {read, 1, ?I2C_M_NO_RD_ACK}]),
+    <<D:1, T:1, S:1, _:5>> = grisp_i2c:msgs([?DS2482_I2C_ADR,
+                                             {read, 1, ?I2C_M_NO_RD_ACK}]),
     {D, T, S}.
-	
-search() ->    
+
+search() ->
+    assert_transaction(),
     bus_reset(),
     write_byte(16#f0),
     L = lists:reverse([ element(1, write_triplet(0)) || _ <- lists:seq(1,64) ]),
     lists:reverse([ Y || <<Y:8>> <= << <<X:1>> || X <- L >> ]).
 
+%--- Callbacks -----------------------------------------------------------------
 
-    
+% @private
+init([]) ->
+    put(?TRANSACTION_KEY, ?TRANSACTION_TOKEN),
+    {ok, []}.
 
-%%% For this to work we need a way to not sending a stop after a msg chain
+% @private
+handle_call({transaction, Fun}, _From, State) ->
+    Reply = try
+        {result, Fun()}
+    catch
+        Class:Reason ->
+            {exception, Class, Reason, erlang:get_stacktrace()}
+    end,
+    {reply, Reply, State}.
 
-%% bus_reset_busy_polling() ->
-%%     grisp_i2c:msgs([?ds2482_i2c_adr, {write, <<?cmd_1wrs>>}]),
-%%     poll_busy(?poll_timeout).
+% @private
+handle_cast(Cast, _State) -> error({unknown_cast, Cast}).
 
-%% poll_busy(Timeout) when Timeout > 0 ->
-%%     case grisp_i2c:msgs([?ds2482_i2c_adr, {read, 1, ?I2C_M_NOSTART}]) of
-%% 	<<_:7, 1:1>> ->
-%% 	    timer:sleep(?poll_interval),
-%% 	    poll_busy(Timeout - ?poll_interval);
-%% 	<<_:7, 0:1>> -> 
-%% check_status(grisp_i2c:msgs([?ds2482_i2c_adr, 
-%% 				 {read, 1, 
-%% 				  ?I2C_M_NOSTART bor ?I2C_M_NO_RD_ACK}]))
-%%     end.
-		  
-	    
+% @private
+handle_info(Info, _State) -> error({unknown_info, Info}).
+
+%--- Internal ------------------------------------------------------------------
+
+assert_transaction() ->
+    case get('$onewire_transaction_token') of
+        ?TRANSACTION_TOKEN -> ok;
+        _                  -> error(no_transaction)
+    end.
+
+map_config(apu)       -> 1;
+map_config(spu)       -> 4;
+map_config(overdrive) -> 8.
+
+check_status(<<_:5, Sd:1, Ppd:1, 0:1>>) ->
+    case {Sd, Ppd} of
+        {0, 0} -> nothing_present;
+        {0, 1} -> presence_detected;
+        {1, _} -> short_detected
+    end;
+check_status(<<_:7, 1:1>>) ->
+    error(bus_reset_busy).

--- a/src/grisp_sup.erl
+++ b/src/grisp_sup.erl
@@ -24,7 +24,8 @@ start_link() ->
             worker(grisp_gpio_events, gen_event, [{local, grisp_gpio_events}]),
             worker(grisp_gpio_poller, []),
             worker(grisp_led, []),
-            worker(grisp_devices, [])
+            worker(grisp_devices, []),
+            worker(grisp_onewire, [])
         ])
     ],
     start_link(?MODULE, Children).

--- a/src/onewire_ds2408.erl
+++ b/src/onewire_ds2408.erl
@@ -1,28 +1,34 @@
 -module(onewire_ds2408).
+% Device: DS2408 - 1-Wire Slave
+% https://datasheets.maximintegrated.com/en/ds/DS2408.pdf
 
-%% Device: DS2408 - 1-Wire Slave
-%% specification can be found at maximintegrated.com
-
-
+% API
 -export([write_channel/2, read_channel/2]).
 
-write_channel(Sel, <<Byte:8>>) ->
-    init_select(Sel),
-    grisp_onewire:write_byte(16#5a),
-    grisp_onewire:write_byte(Byte),
-    grisp_onewire:write_byte(bnot Byte),
-    case grisp_onewire:read_byte() of
-	<<16#aa>> ->
-	    grisp_onewire:read_byte();
-	<<16#ff>> ->
-	    {error, write_channel_fail}
-    end.
+%--- API -----------------------------------------------------------------------
 
+write_channel(Sel, <<Byte:8>>) ->
+    grisp_onewire:transaction(fun() ->
+        init_select(Sel),
+        grisp_onewire:write_byte(16#5a),
+        grisp_onewire:write_byte(Byte),
+        grisp_onewire:write_byte(bnot Byte),
+        case grisp_onewire:read_byte() of
+            <<16#aa>> ->
+                grisp_onewire:read_byte();
+            <<16#ff>> ->
+                {error, write_channel_fail}
+        end
+    end).
 
 read_channel(Sel, Count) ->
-    init_select(Sel),
-    grisp_onewire:write_byte(16#f5),
-    << (grisp_onewire:read_byte()) || _ <- lists:seq(1,Count) >>.
+    grisp_onewire:transaction(fun() ->
+        init_select(Sel),
+        grisp_onewire:write_byte(16#f5),
+        << (grisp_onewire:read_byte()) || _ <- lists:seq(1,Count) >>
+    end).
+
+%--- Internal ------------------------------------------------------------------
 
 init_select(skip_rom) ->
     presence_detected = grisp_onewire:bus_reset(),
@@ -31,7 +37,3 @@ init_select(Id) when is_list(Id) ->
     presence_detected = grisp_onewire:bus_reset(),
     grisp_onewire:write_byte(16#55),
     [ grisp_onewire:write_byte(X) || X <- Id ].
-
-    
-    
-    


### PR DESCRIPTION
Old driver was not concurrency safe, as I2C commands would be interleaved if called from different processes. This new version forces all code to be run from transactions inside a onewire gen_server. The DS2408 driver is updated to use this API (but not tested).