### PR TITLE
[WIP] Update to support RTEMS 5.0

### DIFF
--- a/grisp/grisp_base/drivers/grisp_spi_drv.c
+++ b/grisp/grisp_base/drivers/grisp_spi_drv.c
@@ -65,12 +65,17 @@ static struct grisp_spi_data grisp_spi_data = { NULL, 0, -1 };
 /* Make sure to keep this at sync with the -define(res_max_size.. in spi.erl */
 #define RES_MAX_SIZE 256
 
+static const atsam_spi_config spi_config = {
+  .spi_peripheral_id = ID_SPI0,
+  .spi_regs = SPI0
+};
+
 int grisp_spi_init (void)
 {
     int rv;
 
     /* bus registration */
-    rv = spi_bus_register_atsam(ATSAM_SPI_0_BUS_PATH, ID_SPI0, SPI0, NULL, 0);
+    rv = spi_bus_register_atsam(ATSAM_SPI_0_BUS_PATH, &spi_config);
     assert(rv == 0);
     return 0;
 }

--- a/grisp/grisp_base/grisp.conf
+++ b/grisp/grisp_base/grisp.conf
@@ -1,4 +1,4 @@
 {build, [
-  {post_script, "arm-rtems4.12-objcopy -O binary ${BEAM_PATH} ${BEAM_PATH}.bin"}
+  {post_script, "arm-rtems5-objcopy -O binary ${BEAM_PATH} ${BEAM_PATH}.bin"}
 ]}.
 

--- a/grisp/grisp_base/sys/erl_main.c
+++ b/grisp/grisp_base/sys/erl_main.c
@@ -350,7 +350,8 @@ static void Init(rtems_task_argument arg)
 /*
  * Configure LibBSD.
  */
-#define RTEMS_BSD_CONFIG_BSP_CONFIG
+#include <grisp/libbsd-nexus-config.h>
+
 #define RTEMS_BSD_CONFIG_INIT
 #define RTEMS_BSD_CONFIG_TERMIOS_KQUEUE_AND_POLL
 

--- a/grisp/grisp_base/xcomp/erl-xcomp-20.2.conf
+++ b/grisp/grisp_base/xcomp/erl-xcomp-20.2.conf
@@ -34,8 +34,8 @@
 ## the environment.
 
 ## -- Variables for ARM/RTEMS build --------------------------------------------
-HOST_ARCH="arm-rtems4.12"
-HOST_EXT_ARCH="arm-unknown-rtems4.12"
+HOST_ARCH="arm-rtems5"
+HOST_EXT_ARCH="arm-unknown-rtems5"
 GRISP_OPENSSL_LIB="${GRISP_TC_ROOT}/${HOST_ARCH}/atsamv/lib/libbsd.a"
 XCOMP_SYS_ROOT="/"
 WITH_CRYPTO="yes"


### PR DESCRIPTION
- [X] Fixes #24
- [X] Fixes #25 (fails later at starting the `inet_gethost_native` port instead)
- [X] Un-mounting and re-mounting SD-card "works"
    - [ ] However, changing a file outside of the board still reads the old cached file contents
- [X] (Slight subjective improvement in boot time)
- [ ] As this change makes the runtime files incompatible with RTEMS 4.12, we need to figure out how to coordinate this. Officially tagging a new version of the runtime with release notes that it requires an RTEMS 5.0 toolchain should be enough?