### PR TITLE
Fixed data decoding for 'Digilent PmodMAXSONAR'

### DIFF
--- a/src/pmod_maxsonar.erl
+++ b/src/pmod_maxsonar.erl
@@ -48,7 +48,7 @@ handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
         % Format of response is 'Rxxx\n' where xxx is the decimal
         % representation of the measured range in inches (2.54cm)
         % (left-padded with zeros - so there are always three digits)
-        <<82, D1, D2, D3, 10>> when $0 =< D1, D1 =< $9,
+        <<$R, D1, D2, D3, $\n>> when $0 =< D1, D1 =< $9,
                                       $0 =< D2, D2 =< $9,
                                       $0 =< D3, D3 =< $9 ->
             % Val is given in inches

--- a/src/pmod_maxsonar.erl
+++ b/src/pmod_maxsonar.erl
@@ -45,9 +45,13 @@ handle_cast(Request, _State) -> error({unknown_cast, Request}).
 % @private
 handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
     case Data of
-        <<_, _, D1, D2, D3, 10>> when $0 =< D1, D1 =< $9,
+        % Format of response is 'Rxxx\n' where xxx is the decimal
+        % representation of the measured range in inches (2.54cm)
+        % (left-padded with zeros - so there are always three digits)
+        <<82, D1, D2, D3, 10>> when $0 =< D1, D1 =< $9,
                                       $0 =< D2, D2 =< $9,
                                       $0 =< D3, D3 =< $9 ->
+            % Val is given in inches
             Val = (D1 - $0) * 100 + (D2 - $0) * 10 + (D3 - $0),
             {noreply, State#state{last_val = Val}};
         _ ->


### PR DESCRIPTION
The pattern for matching the data returned by the pmod is
wrong. According to the reference manual (
https://reference.digilentinc.com/_media/reference/pmod/pmodmaxsonar/pmodmaxsonar_rm.pdf
) there is only one 'R'-character in front of the sent distance.

I tested this fix during a GRiSP tutorial session on 06.12.2018:
 - old behavior was that 'undefined' was returned
 - new behavior is that reasonable distances (in inch) are returned

This commit fixes #42 