### PR TITLE
Added a very first version of pmod_gps

### DIFF
--- a/src/pmod_gps.erl
+++ b/src/pmod_gps.erl
@@ -50,21 +50,21 @@ handle_cast(Request, _State) -> error({unknown_cast, Request}).
 handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
     case Data of
         % "$GPGGA...\n"
-        <<36,71,80,71,71,65,_/binary>> ->
+        <<$$,$G,$P,$G,$G,$A,_/binary>> ->
             {noreply, State#state{last_gga = Data}};
         % "$GPGSA...\n"
-        <<36,71,80,71,83,65,_/binary>> ->
+        <<$$,$G,$P,$G,$S,$A,_/binary>> ->
             {noreply, State#state{last_gsa = Data}};
         % "$GPGSV...\n"
-        <<36,71,80,71,83,86,_/binary>> ->
+        <<$$,$G,$P,$G,$S,$V,_/binary>> ->
             {noreply, State#state{last_gsv = Data}};
         % "$GPRMC...\n"
-        <<36,71,80,82,77,67,_/binary>> ->
+        <<$$,$G,$P,$R,$M,$C,_/binary>> ->
             {noreply, State#state{last_rmc = Data}};
         % "$GPVTG...\n"
-        <<36,71,80,86,84,71,_/binary>> ->
+        <<$$,$G,$P,$V,$T,$G,_/binary>> ->
             {noreply, State#state{last_vtg = Data}};
-        <<10>> ->
+        <<$\n>> ->
             {noreply, State};
         _ ->
             {noreply, State}

--- a/src/pmod_gps.erl
+++ b/src/pmod_gps.erl
@@ -1,0 +1,103 @@
+-module(pmod_gps).
+
+-behavior(gen_server).
+
+% API
+-export([start_link/2]).
+-export([get/1]).
+
+% Callbacks
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+-export([code_change/3]).
+-export([terminate/2]).
+
+-include("grisp.hrl").
+
+%--- Records -------------------------------------------------------------------
+
+-record(state, {port, last_gga, last_gsa, last_gsv, last_rmc, last_vtg}).
+
+%--- API -----------------------------------------------------------------------
+
+% @private
+start_link(Slot, _Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Slot, []).
+
+get(Sentence) ->
+    call({get, Sentence}).
+
+%--- Callbacks -----------------------------------------------------------------
+
+% @private
+init(Slot = uart) ->
+    Port = open_port({spawn_driver, "grisp_termios_drv"}, [binary]),
+    grisp_devices:register(Slot, ?MODULE),
+    {ok, #state{port = Port}}.
+
+% @private
+handle_call(Call, _From, State) ->
+    try execute_call(Call, State)
+    catch throw:Reason -> {reply, {error, Reason}, State}
+    end.
+
+% @private
+handle_cast(Request, _State) -> error({unknown_cast, Request}).
+
+% @private
+handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
+    case Data of
+        % "$GPGGA...\n"
+        <<36,71,80,71,71,65,_/binary>> ->
+            {noreply, State#state{last_gga = Data}};
+        % "$GPGSA...\n"
+        <<36,71,80,71,83,65,_/binary>> ->
+            {noreply, State#state{last_gsa = Data}};
+        % "$GPGSV...\n"
+        <<36,71,80,71,83,86,_/binary>> ->
+            {noreply, State#state{last_gsv = Data}};
+        % "$GPRMC...\n"
+        <<36,71,80,82,77,67,_/binary>> ->
+            {noreply, State#state{last_rmc = Data}};
+        % "$GPVTG...\n"
+        <<36,71,80,86,84,71,_/binary>> ->
+            {noreply, State#state{last_vtg = Data}};
+        <<10>> ->
+            {noreply, State};
+        _ ->
+            {noreply, State}
+    end.
+
+
+
+% @private
+code_change(_OldVsn, State, _Extra) -> {ok, State}.
+
+% @private
+terminate(_Reason, _State) -> ok.
+
+%--- Internal -----------------------------------------------------------------
+
+call(Call) ->
+    Dev = grisp_devices:default(?MODULE),
+    case gen_server:call(Dev#device.pid, Call) of
+        {error, Reason} -> error(Reason);
+        Result          -> Result
+    end.
+
+execute_call({get, gga}, #state{last_gga = Gga} = State) ->
+    {reply, Gga, State};
+execute_call({get, gsa}, #state{last_gsa = Gsa} = State) ->
+    {reply, Gsa, State};
+execute_call({get, gsv}, #state{last_gsv = Gsv} = State) ->
+    {reply, Gsv, State};
+execute_call({get, rmc}, #state{last_rmc = Rmc} = State) ->
+    {reply, Rmc, State};
+execute_call({get, vtg}, #state{last_vtg = Vtc} = State) ->
+    {reply, Vtc, State};
+execute_call({get, Sentence}, State) ->
+    error({unknown_sentence, Sentence}, State);
+execute_call(Request, State) ->
+    error({unknown_call, Request}, State).


### PR DESCRIPTION
This new device driver can fetch GPS NMEA sentences from a
'Digilent PmodGPS'.
This first version was shamelessly copied and adapted from
pmod_maxsonar.erl

It listens to the stream of incoming NMEA sentences and stores the
latest version of each of the four supported sentences (GGA, GSA, GSV,
RMC and VTG).

You can get the latest sentence by calling e.g. pmod_gps:get(gga).
The driver does not split up and further analyse the received sentences
- this could be a good starting point for extending the driver.

PS: This driver was coded during a GRiSP tutorial on 06.12.2018
PPS: Beware! I have no clue of erlang, so please proof-read ;-)