### PR TITLE
Quickfix decoding pattern

### DIFF
--- a/src/pmod_maxsonar.erl
+++ b/src/pmod_maxsonar.erl
@@ -54,6 +54,14 @@ handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
             % Val is given in inches
             Val = (D1 - $0) * 100 + (D2 - $0) * 10 + (D3 - $0),
             {noreply, State#state{last_val = Val}};
+        % All subsequent calls to pmod_maxsonar:get/0 will return
+        % The same value if the case clause below is not present
+        <<_, _, D1, D2, D3, $\n>> when $0 =< D1, D1 =< $9,
+                                      $0 =< D2, D2 =< $9,
+                                      $0 =< D3, D3 =< $9 ->
+            % Val is given in inches
+            Val = (D1 - $0) * 100 + (D2 - $0) * 10 + (D3 - $0),
+            {noreply, State#state{last_val = Val}};
         _ ->
             {noreply, State}
     end.

--- a/src/pmod_maxsonar.erl
+++ b/src/pmod_maxsonar.erl
@@ -54,8 +54,9 @@ handle_info({Port, {data, Data}}, #state{port = Port} = State) ->
             % Val is given in inches
             Val = (D1 - $0) * 100 + (D2 - $0) * 10 + (D3 - $0),
             {noreply, State#state{last_val = Val}};
-        % All subsequent calls to pmod_maxsonar:get/0 will return
-        % The same value if the case clause below is not present
+        % Sometimes for no obvious reason we receive
+        % a different value from the sonar.
+        % Instead of $R we get two garbage characters
         <<_, _, D1, D2, D3, $\n>> when $0 =< D1, D1 =< $9,
                                       $0 =< D2, D2 =< $9,
                                       $0 =< D3, D3 =< $9 ->


### PR DESCRIPTION
This is perhaps only a temporary workaround as I am still quite unsure about why the 6-part pattern must be matched in order to fetch range values correctly. But it might be a good start as I have tested and verified this on multiple boards and using different Pmod_MAXSONAR modules :

- The current version of the driver will always return a single value regardless of the actual reading of the sensor. Calling `port_info(TermiosPort)` shows that there is lots of input from the port but the data doesn't match against the required pattern therefore the value returned by `pmod_maxsonar:get/0` remains the same.
- With the second clause added, the expected behavior is achieved, and the returned values in inches are relatively accurate.

I hope this helps 🙂