### PR TITLE
Remove deprecated maintainers section

### DIFF
--- a/src/grisp.app.src
+++ b/src/grisp.app.src
@@ -11,12 +11,6 @@
     {env,[]},
     {modules, []},
 
-    % Hex.pm
-    {maintainers, [
-        "Adam Lindberg",
-        "Peer Stritzinger",
-        "Sebastien Merle"
-    ]},
     {licenses, [
         "Apache License 2.0"
     ]},


### PR DESCRIPTION
Prevents me from publishing to hex.pm.
See https://github.com/hexpm/hex/blob/master/CHANGELOG.md#ignoring-maintainers-field