### PR TITLE
Fix binary decoding

### DIFF
--- a/src/pmod_nav.erl
+++ b/src/pmod_nav.erl
@@ -1068,7 +1068,7 @@ convert_dps(Raw, Context, Opts) ->
     {Result, NewContext}.
 
 convert_gauss(Raw, Context, Opts) ->
-    Value = decode(unsigned_little, Raw),
+    Value = decode(signed_little, Raw),
     Scale = case maps:get(mag_unit, Opts, gauss) of
         gauss  -> 0.001;
         mgauss -> 1.0;


### PR DESCRIPTION
Following a discussion on slack, it appears that the value of the magnetic field is expressed as two’s complement and must be decoded as signed_little. This can be verified in sections 8.11 to 8.13 from [https://www.st.com/resource/en/datasheet/lsm9ds1.pdf](https://www.st.com/resource/en/datasheet/lsm9ds1.pdf).
Thank you @peerst and @eproxus.