### PR TITLE
Remove unused env variables

### DIFF
--- a/grisp/grisp2/common/build/files/xcomp/erl-xcomp-arm-rtems5.conf
+++ b/grisp/grisp2/common/build/files/xcomp/erl-xcomp-arm-rtems5.conf
@@ -63,7 +63,7 @@ CCLINK_FLAGS="-Wl,-Map,${RTEMS_BSP}.map"
 
 ## Custom GRiSP config
 
-GRISP_CFLAGS="-DGRISP -DGRISP_PLATFORM=${GRISP_PLATFORM} -I${PROJECT_LIB}/include -I${PROJECT_LIB}/include/cryptoauthlib"
+GRISP_CFLAGS="-I${PROJECT_LIB}/include -I${PROJECT_LIB}/include/cryptoauthlib"
 GRISP_LDFLAGS="-L${PROJECT_LIB}"
 
 ## Crypto

--- a/grisp/grisp_base/23/build/files/xcomp/erl-xcomp-arm-rtems5.conf
+++ b/grisp/grisp_base/23/build/files/xcomp/erl-xcomp-arm-rtems5.conf
@@ -63,7 +63,7 @@ CCLINK_FLAGS="-Wl,-Map,${RTEMS_BSP}.map"
 
 ## Custom GRiSP config
 
-GRISP_CFLAGS="-DGRISP -DGRISP_PLATFORM=${GRISP_PLATFORM}"
+GRISP_CFLAGS=""
 GRISP_LDFLAGS="-qnolinkcmds -T linkcmds.sdram"
 
 ## Crypto


### PR DESCRIPTION
The GRISP env variables are migrated to libgrisp.