### PR TITLE
Modifying blas to the toolchain cross compilation

### DIFF
--- a/grisp/grisp2/24/build/files/xcomp/erl-xcomp-arm-rtems5-24.conf
+++ b/grisp/grisp2/24/build/files/xcomp/erl-xcomp-arm-rtems5-24.conf
@@ -157,7 +157,7 @@ LD="${GRISP_TC_ROOT}/bin/${RTEMS_TARGET}-ld ${SYSFLAGS}"
 LDFLAGS="${CPU_CFLAGS} ${OPTFLAGS} ${BSP_LDFLAGS} ${CCLINK_FLAGS} ${GRISP_LDFLAGS}"
 
 # * `LIBS' - Libraries.
-LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lopenblas"
+LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lblas"
 
 ## -- *D*ynamic *E*rlang *D*river Linking --
 

--- a/grisp/grisp2/25/build/files/xcomp/erl-xcomp-arm-rtems5-25.conf
+++ b/grisp/grisp2/25/build/files/xcomp/erl-xcomp-arm-rtems5-25.conf
@@ -157,7 +157,7 @@ LD="${GRISP_TC_ROOT}/bin/${RTEMS_TARGET}-ld ${SYSFLAGS}"
 LDFLAGS="${CPU_CFLAGS} ${OPTFLAGS} ${BSP_LDFLAGS} ${CCLINK_FLAGS} ${GRISP_LDFLAGS}"
 
 # * `LIBS' - Libraries.
-LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lopenblas"
+LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lblas"
 
 ## -- *D*ynamic *E*rlang *D*river Linking --
 

--- a/grisp/grisp2/common/build/files/xcomp/erl-xcomp-arm-rtems5.conf
+++ b/grisp/grisp2/common/build/files/xcomp/erl-xcomp-arm-rtems5.conf
@@ -156,7 +156,7 @@ LD="${GRISP_TC_ROOT}/bin/${RTEMS_TARGET}-ld ${SYSFLAGS}"
 LDFLAGS="${CPU_CFLAGS} ${OPTFLAGS} ${BSP_LDFLAGS} ${CCLINK_FLAGS} ${GRISP_LDFLAGS}"
 
 # * `LIBS' - Libraries.
-LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lopenblas"
+LIBS="-lgrisp -lbsd -lrtemsdefaultconfig -linih -lcryptoauth -lblas"
 
 ## -- *D*ynamic *E*rlang *D*river Linking --
 


### PR DESCRIPTION
Switched from libopenblas to libblas, to reflect the change of blas implementation.