### PR TITLE
Fix CI on OTP 23

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
-          rebar3-version: ${{matrix.rebar3}}
+          rebar3-version: ${{ matrix.otp == '23' && '3.20.0' || matrix.rebar3 }}
 
       - uses: actions/cache@v2
         env:


### PR DESCRIPTION
The setup-beam action uses precompiled rebar3 binaries. 
The latest ones don't support OTP 23, so we have to manually pick the last working rebar3 version for OTP 23.