### PR TITLE
Add support for shell option in grisp.ini template.

### DIFF
--- a/grisp/grisp2/common/deploy/files/grisp.ini.mustache
+++ b/grisp/grisp2/common/deploy/files/grisp.ini.mustache
@@ -1,5 +1,6 @@
 [erlang]
 args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -bindir {{release_name}}/erts-{{erts_vsn}}/bin -boot {{release_name}}/releases/{{release_version}}/start -config {{release_name}}/releases/{{release_version}}/sys.config
+shell = erlang
 
 [network]
 ip_self=dhcp

--- a/grisp/grisp_base/common/deploy/files/grisp.ini.mustache
+++ b/grisp/grisp_base/common/deploy/files/grisp.ini.mustache
@@ -3,6 +3,7 @@ image_path = /media/mmcsd-0-0/{{release_name}}/erts-{{erts_vsn}}/bin/beam
 
 [erlang]
 args = erl.rtems -C multi_time_warp -- -mode embedded -home . -pa . -root {{release_name}} -boot {{release_name}}/releases/{{release_version}}/start -config {{release_name}}/releases/{{release_version}}/sys.config
+shell = erlang
 
 [network]
 ip_self=dhcp


### PR DESCRIPTION
The new shell option under the erlang section can now be set to either erlang (the default if not set), rtems or none.