### PR TITLE
Use DHCP provided DNS by default

### DIFF
--- a/grisp/default/common/build/files/erts/emulator/sys/unix/erl_main.c
+++ b/grisp/default/common/build/files/erts/emulator/sys/unix/erl_main.c
@@ -64,7 +64,6 @@
 #define DEFAULT_MNT "/media/mmcsd-0-0/"
 #endif
 #define INI_FILENAME "grisp.ini"
-#define DHCP_CONF_FILENAME "dhcpcd.conf"
 
 #define STACK_SIZE_INIT_TASK (512 * 1024)
 
@@ -677,8 +676,6 @@ static void Init(rtems_task_argument arg) {
 
   strlcpy(inifile, rootdir, 192);
   strlcat(inifile, INI_FILENAME, 192);
-  strlcpy(dhcpfile, rootdir, 192);
-  strlcat(dhcpfile, DHCP_CONF_FILENAME, 192);
 
   printf("[ERL] Reading %s\n", inifile);
   erl_args = strdup(default_erl_args);
@@ -695,12 +692,7 @@ static void Init(rtems_task_argument arg) {
   if (start_dhcp) {
     printf("[ERL] Starting DHCP\n");
     grisp_led_set1(false, true, true);
-    if (!access(dhcpfile, F_OK)) {
-      printf("[ERL] Using config file %s\n", DHCP_CONF_FILENAME);
-      grisp_init_dhcpcd_with_config(PRIO_DHCP, dhcpfile);
-    } else {
-      grisp_init_dhcpcd(PRIO_DHCP);
-    }
+    grisp_init_dhcpcd(PRIO_DHCP);
   }
 
   if (wlan_enable) {

--- a/grisp/default/common/build/files/erts/emulator/sys/unix/erl_main.c
+++ b/grisp/default/common/build/files/erts/emulator/sys/unix/erl_main.c
@@ -695,10 +695,12 @@ static void Init(rtems_task_argument arg) {
   if (start_dhcp) {
     printf("[ERL] Starting DHCP\n");
     grisp_led_set1(false, true, true);
-    if (!access(dhcpfile, F_OK))
+    if (!access(dhcpfile, F_OK)) {
+      printf("[ERL] Using config file %s\n", DHCP_CONF_FILENAME);
       grisp_init_dhcpcd_with_config(PRIO_DHCP, dhcpfile);
-    else
+    } else {
       grisp_init_dhcpcd(PRIO_DHCP);
+    }
   }
 
   if (wlan_enable) {

--- a/grisp/default/common/deploy/files/etc/dhcpcd.conf
+++ b/grisp/default/common/deploy/files/etc/dhcpcd.conf
@@ -1,0 +1,35 @@
+# A sample configuration for dhcpcd.
+# See dhcpcd.conf(5) for details.
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+#clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Most distributions have NTP support.
+option ntp_servers
+# Respect the network MTU.
+# Some interface drivers reset when changing the MTU so disabled by default.
+#option interface_mtu
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# A hook script is provided to lookup the hostname if not set by the DHCP
+# server, but it should not be run by default.
+nohook lookup-hostname

--- a/grisp/default/common/deploy/files/etc/dhcpcd.conf
+++ b/grisp/default/common/deploy/files/etc/dhcpcd.conf
@@ -30,6 +30,6 @@ option ntp_servers
 # A ServerID is required by RFC2131.
 require dhcp_server_identifier
 
-# A hook script is provided to lookup the hostname if not set by the DHCP
-# server, but it should not be run by default.
-nohook lookup-hostname
+# Uncomment to disable resolv.conf overwriting.
+# This is required if the user wants to provide a static resolv.conf
+# nohook resolv.conf

--- a/grisp/default/common/deploy/files/etc/resolv.conf
+++ b/grisp/default/common/deploy/files/etc/resolv.conf
@@ -1,4 +1,1 @@
 domain grisp.local
-# dns.sb
-nameserver 185.222.222.222
-nameserver 45.11.45.11


### PR DESCRIPTION
By setting up `domain_name_servers` option in `/etc/dhcpcd.conf` we can receive such information, if available, through a dhcpcd hook.

The hook has been added in libgrisp, but we could move it in this repo if we want more flexibility.
This PR adds the hook, https://github.com/grisp/libgrisp/pull/5 and has been tested on an RTEMS6 so it needs testing for RTEMS5.

The hook will overwrite the `/etc/resolv.conf` file each time a `new_domain_name_servers` enviroment value is given by dhcpcd. This means that if the DHCP server changes DNS, the change will be reflected in the resolv.conf.

The dhcp server sends the DNS IPs only if asked about them. If the user wants to have its own resolv.conf, he or she can write it down and provide either an empty `dhcpcd.conf` or one without the `domain_name_servers` option.