### PR TITLE
Add workflow to automate OTP package creation

### DIFF
--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -1,4 +1,4 @@
-name: OTP package generation
+name: OTP Package
 
 on:
   pull_request:
@@ -65,15 +65,21 @@ jobs:
             rebar3 grisp build --tar
             PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
             echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
-        - name: Upload as GitHub Artifact
+        - name: Deploy test
           if: ${{ steps.build.outcome == 'success' }}
+          id: deploy-test
+          working-directory: robot
+          run: |
+            rebar3 grisp deploy
+        - name: Upload as GitHub Artifact
+          if: ${{ steps.deploy-test.outcome == 'success' }}
           continue-on-error: true
           uses: actions/upload-artifact@v4
           with:
             name: ${{env.pkg_name}}
             path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
         - name: Upload to S3
-          if: ${{ steps.build.outcome == 'success' }}
+          if: ${{ steps.deploy-test.outcome == 'success' }}
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -1,19 +1,23 @@
 name: OTP Package
 
 on:
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch:
   repository_dispatch:
     types:
       - new-otp-release
 
-# ${{ github.event.client_payload.otp }}
-
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      otp-versions: ${{ steps.matrix-def.outputs.otp-versions }}
+    steps:
+      - name: Matrix Definition
+        id: matrix-def
+        run: |
+           echo "otp-versions=['${{ github.event.client_payload.otp }}']" >> "$GITHUB_OUTPUT"
   otp-gen-matrix:
     runs-on: ubuntu-latest
+    needs: define-matrix
     container:
       # This image is based on debian:bookworm
       # but we need to make  erlef/setup-beam@v1 happy
@@ -23,7 +27,7 @@ jobs:
         ImageOS: 'ubuntu22'
     strategy:
       matrix:
-        otp: ['27.0']
+        otp: ${{ fromJson(needs.define-matrix.outputs.otp-versions) }}
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
       fail-fast: false

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -1,0 +1,55 @@
+name: OTP package generation
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - new-otp-release
+
+# ${{ github.event.client_payload.otp }}
+
+jobs:
+    otp-gen-matrix:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          otp: ['27.0.1']
+          deps: ['grisp']
+          rebar3: ['3']
+      steps:
+        - uses: erlef/setup-beam@v1
+          with:
+            otp-version: ${{matrix.otp}}
+            rebar3-version: ${{ matrix.rebar3 }}
+        - name: Install GRiSP Plugin
+          run: |
+            mkdir -p ${HOME}/.config/rebar3/
+            echo "{plugins, [rebar3_hex,rebar3_grisp]}." > ${HOME}/.config/rebar3/rebar.config
+            rebar3
+        - name: Generate Dummy Project
+          run: |
+            rebar3 grisp configure -i false --otp_version="${{matrix.otp}}"
+        - name: Edit rebar.config
+          run: |
+            TOOLCHAIN_DIR=$(pwd)/toolchain
+            sed -i '/{grisp, \[/a\
+            '"{build, [{toolchain, [{directory, \"$TOOLCHAIN_DIR\"}]}]}," robot/rebar.config
+            sed -i '/{deps, \[/,/\]}.*/{
+            N
+            N
+            s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
+            }' robot/rebar.config
+            cat robot/rebar.config
+        - name: Prepare Toolchain
+          run: |
+            TOOLCHAIN="grisp2-rtems-toolchain_Linux_5.11.0-1027-azure_e2c29d3374d9046af01af570f6a85a6aa99546bb"
+            wget https://grisp.s3.amazonaws.com/platforms/grisp2/toolchain/${TOOLCHAIN}.tar.gz -q
+            mkdir toolchain
+            tar -xvzf ${TOOLCHAIN}.tar.gz -C toolchain
+        - name: Build OTP
+          run: |
+            cd robot
+            rebar3 grisp build --tar

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -14,6 +14,13 @@ on:
 jobs:
     otp-gen-matrix:
       runs-on: ubuntu-latest
+      container:
+        # This image is based on debian:bookworm
+        # but we need to make  erlef/setup-beam@v1 happy
+        # so we set 'ubuntu22' (jammy) which is the most similar
+        image: grisp/grisp2-rtems-toolchain
+        env:
+          ImageOS: 'ubuntu22'
       strategy:
         matrix:
           otp: ['27.0.1']
@@ -36,20 +43,27 @@ jobs:
           run: |
             TOOLCHAIN_DIR=$(pwd)/toolchain
             sed -i '/{grisp, \[/a\
-            '"{build, [{toolchain, [{directory, \"$TOOLCHAIN_DIR\"}]}]}," robot/rebar.config
+            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," robot/rebar.config
             sed -i '/{deps, \[/,/\]}.*/{
             N
             N
             s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
             }' robot/rebar.config
             cat robot/rebar.config
-        - name: Prepare Toolchain
-          run: |
-            TOOLCHAIN="grisp2-rtems-toolchain_Linux_5.11.0-1027-azure_e2c29d3374d9046af01af570f6a85a6aa99546bb"
-            wget https://grisp.s3.amazonaws.com/platforms/grisp2/toolchain/${TOOLCHAIN}.tar.gz -q
-            mkdir toolchain
-            tar -xvzf ${TOOLCHAIN}.tar.gz -C toolchain
+        # - name: Prepare Toolchain
+        #   run: |
+        #     TOOLCHAIN="grisp2-rtems-toolchain_Linux_5.11.0-1027-azure_e2c29d3374d9046af01af570f6a85a6aa99546bb"
+        #     wget https://grisp.s3.amazonaws.com/platforms/grisp2/toolchain/${TOOLCHAIN}.tar.gz -q
+        #     mkdir toolchain
+        #     tar -xvzf ${TOOLCHAIN}.tar.gz -C toolchain
         - name: Build OTP
           run: |
             cd robot
             rebar3 grisp build --tar
+            PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
+            echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+        - name: Upload OTP Artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ env.pkg_name }}
+            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -12,79 +12,87 @@ on:
 # ${{ github.event.client_payload.otp }}
 
 jobs:
-    otp-gen-matrix:
-      runs-on: ubuntu-latest
-      container:
-        # This image is based on debian:bookworm
-        # but we need to make  erlef/setup-beam@v1 happy
-        # so we set 'ubuntu22' (jammy), which is the most similar, as ImageOS
-        image: grisp/grisp2-rtems-toolchain
+  otp-gen-matrix:
+    runs-on: ubuntu-latest
+    container:
+      # This image is based on debian:bookworm
+      # but we need to make  erlef/setup-beam@v1 happy
+      # so we set 'ubuntu22' (jammy), which is the most similar, as ImageOS
+      image: grisp/grisp2-rtems-toolchain
+      env:
+        ImageOS: 'ubuntu22'
+    strategy:
+      matrix:
+        otp: ['27.0']
+        deps: ['grisp', 'grisp, grisp_cryptoauth']
+        rebar3: ['3']
+      fail-fast: false
+    steps:
+      - name: Install AWS CLI
+        run: |
+          apt update
+          apt install curl unzip -y
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          aws --version
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{ matrix.rebar3 }}
+      - name: Install GRiSP Plugin
+        run: |
+          mkdir -p ${HOME}/.config/rebar3/
+          echo "{plugins, [rebar3_hex,rebar3_grisp]}." > ${HOME}/.config/rebar3/rebar.config
+          rebar3
+      - name: Generate Dummy Project
+        run: |
+          rebar3 grisp configure -i false --otp_version="=${{matrix.otp}}" --dest="_deploy"
+          mkdir robot/_deploy
+          sed -i 's/grisp/${{matrix.deps}}/g' robot/src/robot.app.src
+          sed -i '/{deps, \[/,/\]}.*/{
+          N
+          N
+          s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
+          }' robot/rebar.config
+          cat robot/rebar.config
+      - name: Try to Deploy
+        id: deploy
+        continue-on-error: true
+        working-directory: robot
+        run: |
+          rebar3 grisp deploy
+      - name: Build OTP
+        id: build
+        if: ${{ steps.deploy.outcome == 'failure' }}
+        working-directory: robot
+        run: |
+          sed -i '/{grisp, \[/a\
+          '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," rebar.config
+          cat rebar.config
+          rebar3 grisp build --tar
+          PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
+          echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+      - name: Deploy test
+        if: ${{ steps.build.outcome == 'success' }}
+        id: deploy-test
+        working-directory: robot
+        run: |
+          rebar3 grisp deploy
+      - name: Upload as GitHub Artifact
+        id: artifact-upload
+        if: ${{ steps.deploy-test.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{env.pkg_name}}
+          path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
+
+      - name: Upload to S3
         env:
-          ImageOS: 'ubuntu22'
-      strategy:
-        matrix:
-          otp: ['27.0']
-          deps: ['grisp', 'grisp, grisp_cryptoauth']
-          rebar3: ['3']
-        fail-fast: false
-      steps:
-        - uses: erlef/setup-beam@v1
-          with:
-            otp-version: ${{matrix.otp}}
-            rebar3-version: ${{ matrix.rebar3 }}
-        - name: Install GRiSP Plugin
-          run: |
-            mkdir -p ${HOME}/.config/rebar3/
-            echo "{plugins, [rebar3_hex,rebar3_grisp]}." > ${HOME}/.config/rebar3/rebar.config
-            rebar3
-        - name: Generate Dummy Project
-          run: |
-            rebar3 grisp configure -i false --otp_version="=${{matrix.otp}}" --dest="_deploy"
-            mkdir robot/_deploy
-            sed -i 's/grisp/${{matrix.deps}}/g' robot/src/robot.app.src
-            sed -i '/{deps, \[/,/\]}.*/{
-            N
-            N
-            s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
-            }' robot/rebar.config
-            cat robot/rebar.config
-        - name: Try to Deploy
-          id: deploy
-          continue-on-error: true
-          working-directory: robot
-          run: |
-            rebar3 grisp deploy
-        - name: Build OTP
-          id: build
-          if: ${{ steps.deploy.outcome == 'failure' }}
-          working-directory: robot
-          run: |
-            sed -i '/{grisp, \[/a\
-            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," rebar.config
-            cat rebar.config
-            rebar3 grisp build --tar
-            PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
-            echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
-        - name: Deploy test
-          if: ${{ steps.build.outcome == 'success' }}
-          id: deploy-test
-          working-directory: robot
-          run: |
-            rebar3 grisp deploy
-        - name: Upload as GitHub Artifact
-          if: ${{ steps.deploy-test.outcome == 'success' }}
-          continue-on-error: true
-          uses: actions/upload-artifact@v4
-          with:
-            name: ${{env.pkg_name}}
-            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
-        - name: Upload to S3
-          if: ${{ steps.deploy-test.outcome == 'success' }}
-          env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}
-            AWS_DEFAULT_REGION: "us-east-1"
-          run: |
-            aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
-            robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
-            s3://grisp/platforms/grisp2/otp/
+          AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
+          robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
+          s3://grisp/platforms/grisp2/otp/

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -24,7 +24,7 @@ jobs:
       strategy:
         matrix:
           otp: ['27.0.1']
-          deps: ['grisp', ['grisp, grisp_cryptoauth'], ['grisp, grisp_connect']]
+          deps: ['grisp', 'grisp, grisp_cryptoauth', 'grisp, grisp_connect']
           rebar3: ['3']
       steps:
         - uses: erlef/setup-beam@v1
@@ -51,28 +51,24 @@ jobs:
         - name: Try to Deploy
           id: deploy
           continue-on-error: true
-          run: | # rebar3 grisp deploy
-            exit 0
-        - name: Add Build settings to rebar.config
+          run: |
+            cd robot
+            rebar3 grisp deploy
+        - name: Build OTP
+          id: build
           if: ${{ steps.deploy.outcome == 'failure' }}
           run: |
             TOOLCHAIN_DIR=$(pwd)/toolchain
             sed -i '/{grisp, \[/a\
             '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," robot/rebar.config
             cat robot/rebar.config
-        - name: Ciao
-          run: |
-            echo ciao
-        # - name: Build OTP
-        #   if:
-        #   run: |
-        #     cd robot
-        #     rebar3 grisp build --tar
-        #     PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
-        #     echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
-        # - name: Upload OTP Artifact
-        #   if:
-        #   uses: actions/upload-artifact@v4
-        #   with:
-        #     name: ${{ env.pkg_name }}
-        #     path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz
+            cd robot
+            rebar3 grisp build --tar
+            PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
+            echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+        - name: Upload OTP Artifact
+          if: ${{ steps.build.outcome == 'success' }}
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ env.pkg_name }}
+            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -26,6 +26,7 @@ jobs:
           otp: ['27.0']
           deps: ['grisp', 'grisp, grisp_cryptoauth']
           rebar3: ['3']
+        fail-fast: false
       steps:
         - uses: erlef/setup-beam@v1
           with:
@@ -38,7 +39,7 @@ jobs:
             rebar3
         - name: Generate Dummy Project
           run: |
-            rebar3 grisp configure -i false --otp_version="${{matrix.otp}}" --dest="_deploy"
+            rebar3 grisp configure -i false --otp_version="=${{matrix.otp}}" --dest="_deploy"
             mkdir robot/_deploy
             sed -i 's/grisp/${{matrix.deps}}/g' robot/src/robot.app.src
             sed -i '/{deps, \[/,/\]}.*/{
@@ -64,9 +65,20 @@ jobs:
             rebar3 grisp build --tar
             PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
             echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
-        - name: Upload OTP Artifact
+        - name: Upload as GitHub Artifact
           if: ${{ steps.build.outcome == 'success' }}
+          continue-on-error: true
           uses: actions/upload-artifact@v4
           with:
-            name: ${{ env.pkg_name }}
-            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz
+            name: ${{env.pkg_name}}
+            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
+        - name: Upload to S3
+          if: ${{ steps.build.outcome == 'success' }}
+          env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}
+            AWS_DEFAULT_REGION: "us-east-1"
+          run: |
+            aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
+            robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
+            s3://grisp/platforms/grisp2/otp/

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -38,32 +38,41 @@ jobs:
             rebar3
         - name: Generate Dummy Project
           run: |
-            rebar3 grisp configure -i false --otp_version="${{matrix.otp}}"
-        - name: Edit rebar.config
+            rebar3 grisp configure -i false --otp_version="${{matrix.otp}}" --dest="_deploy"
+            mkdir robot/_deploy
+        - name: Add Selected Deps to rebar.config
           run: |
-            TOOLCHAIN_DIR=$(pwd)/toolchain
-            sed -i '/{grisp, \[/a\
-            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," robot/rebar.config
             sed -i '/{deps, \[/,/\]}.*/{
             N
             N
             s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
             }' robot/rebar.config
             cat robot/rebar.config
-        # - name: Prepare Toolchain
-        #   run: |
-        #     TOOLCHAIN="grisp2-rtems-toolchain_Linux_5.11.0-1027-azure_e2c29d3374d9046af01af570f6a85a6aa99546bb"
-        #     wget https://grisp.s3.amazonaws.com/platforms/grisp2/toolchain/${TOOLCHAIN}.tar.gz -q
-        #     mkdir toolchain
-        #     tar -xvzf ${TOOLCHAIN}.tar.gz -C toolchain
-        - name: Build OTP
+        - name: Try to Deploy
+          id: deploy
+          continue-on-error: true
+          run: | # rebar3 grisp deploy
+            exit 0
+        - name: Add Build settings to rebar.config
+          if: ${{ steps.deploy.outcome == 'failure' }}
           run: |
-            cd robot
-            rebar3 grisp build --tar
-            PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
-            echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
-        - name: Upload OTP Artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: ${{ env.pkg_name }}
-            path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz
+            TOOLCHAIN_DIR=$(pwd)/toolchain
+            sed -i '/{grisp, \[/a\
+            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," robot/rebar.config
+            cat robot/rebar.config
+        - name: Ciao
+          run: |
+            echo ciao
+        # - name: Build OTP
+        #   if:
+        #   run: |
+        #     cd robot
+        #     rebar3 grisp build --tar
+        #     PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
+        #     echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+        # - name: Upload OTP Artifact
+        #   if:
+        #   uses: actions/upload-artifact@v4
+        #   with:
+        #     name: ${{ env.pkg_name }}
+        #     path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/grisp_otp_build_${{matrix.otp}}_*.tar.gz

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Matrix Definition
         id: matrix-def
         run: |
-           echo "otp-versions=['${{ github.event.client_payload.otp }}']" >> "$GITHUB_OUTPUT"
+           echo "otp-versions=${{ github.event.client_payload.otp }}" >> "$GITHUB_OUTPUT"
   otp-gen-matrix:
     runs-on: ubuntu-latest
     needs: define-matrix

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -17,14 +17,14 @@ jobs:
       container:
         # This image is based on debian:bookworm
         # but we need to make  erlef/setup-beam@v1 happy
-        # so we set 'ubuntu22' (jammy) which is the most similar
+        # so we set 'ubuntu22' (jammy), which is the most similar, as ImageOS
         image: grisp/grisp2-rtems-toolchain
         env:
           ImageOS: 'ubuntu22'
       strategy:
         matrix:
           otp: ['27.0.1']
-          deps: ['grisp']
+          deps: ['grisp', ['grisp, grisp_cryptoauth'], ['grisp, grisp_connect']]
           rebar3: ['3']
       steps:
         - uses: erlef/setup-beam@v1

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -23,8 +23,8 @@ jobs:
           ImageOS: 'ubuntu22'
       strategy:
         matrix:
-          otp: ['27.0.1']
-          deps: ['grisp', 'grisp, grisp_cryptoauth', 'grisp, grisp_connect']
+          otp: ['27.0']
+          deps: ['grisp', 'grisp, grisp_cryptoauth']
           rebar3: ['3']
       steps:
         - uses: erlef/setup-beam@v1
@@ -40,8 +40,7 @@ jobs:
           run: |
             rebar3 grisp configure -i false --otp_version="${{matrix.otp}}" --dest="_deploy"
             mkdir robot/_deploy
-        - name: Add Selected Deps to rebar.config
-          run: |
+            sed -i 's/grisp/${{matrix.deps}}/g' robot/src/robot.app.src
             sed -i '/{deps, \[/,/\]}.*/{
             N
             N
@@ -51,18 +50,17 @@ jobs:
         - name: Try to Deploy
           id: deploy
           continue-on-error: true
+          working-directory: robot
           run: |
-            cd robot
             rebar3 grisp deploy
         - name: Build OTP
           id: build
           if: ${{ steps.deploy.outcome == 'failure' }}
+          working-directory: robot
           run: |
-            TOOLCHAIN_DIR=$(pwd)/toolchain
             sed -i '/{grisp, \[/a\
-            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," robot/rebar.config
-            cat robot/rebar.config
-            cd robot
+            '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," rebar.config
+            cat rebar.config
             rebar3 grisp build --tar
             PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
             echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -92,6 +92,7 @@ jobs:
           path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
 
       - name: Upload to S3
+        if: ${{ steps.deploy-test.outcome == 'success' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Workflow actions:

Trigger: repository_dispatch -> will only run on the default branch and only if triggered by an API call

An OTP package for each deps combo will be produced using latest versions from hex.pm packages.

1. Use `grisp/grisp2-rtems-toolchain` docker image
2. Install AWS CLI
3. Run BEAM Setup with desired OTP release
4. Setup dummy project
5. Attempt a Deployment to verify if the package is available or not
Next steps run only if needed
7. Build OTP
8. Verify deployment success
9. upload as github artifact
10. Publish on S3

How to trigger a run to build 27.0 packages using github CLI:

```shell

gh api \
  --method POST \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/grisp/trigger_test/dispatches \
  -f "event_type=new-otp-release" \
  -F "client_payload[otp]=[\\\"27.0\\\", \\\"26.2.5.1\\\"]" \
  -F "client_payload[unit]=false" \
  -F "client_payload[integration]=true"

```
