### PR TITLE
Add chron job to check erlang/otp releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# Manually trigger OTP package generation
+
+Here is a quick example with the GitHub CLI, for more info refer to the [docs](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event).
+You can do this whenever you see we are missing one or more releases, you can pass multiple versions in the list.
+
+```shell
+gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/grisp/grisp/dispatches \
+  -f "event_type=new-otp-release" \
+  -F "client_payload[otp]=[\\\"27.0\\\", \\\"26.2.5.1\\\"]" \
+  -F "client_payload[unit]=false" \
+  -F "client_payload[integration]=true"
+```

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -1,0 +1,40 @@
+name: Check OTP Release
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 * * * *' # At the beginning of every hour
+
+jobs:
+  check-otp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        id: version-cache
+        env:
+          cache-name: cached-version
+        with:
+          path: last_cached_ver.txt
+          key: ${{env.cache-name}}
+      - name: Cache latest version
+        if: steps.version-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sL https://api.github.com/repos/erlang/otp/releases/latest | \
+          jq -r ".tag_name" > last_cached_ver.txt
+      - name: Compare with Latest Release Number
+        id: compare-vsn
+        continue-on-error: true
+        run: |
+          curl -sL https://api.github.com/repos/erlang/otp/releases/latest | \
+          jq -r ".tag_name" > last_seen_ver.txt
+          diff last_cached_ver.txt last_seen_ver.txt
+      - name: Trigger OTP package build
+        if: ${{ steps.compare-vsn.outcome == 'failure' }}
+        run: |
+          OTP=$(cat last_seen_ver.txt | awk -F'-' '{print $2}')
+          echo $OTP
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            https://api.github.com/repos/grisp/grisp/dispatches \
+            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"[\\\\\\\"${OTP}\\\\\\\"]\",\"unit\":false,\"integration\":true}}"


### PR DESCRIPTION
### Chron job
This script will run at the start of every hour, avarage execution time is 15 seconds.

### Logic

1. First thing is to load a cache file with the last known otp version.
2. On the first run this will fail the cache hit, in this case we write the cache file with the latest OTP version. 
3. In any case we follow by fetching the latest version and compare it with the cached version file.
4. If the comparison fails we issue a repository dispatch with the version number.

### Note
The OTP version number has a ton of escapes because I need to send it as a Json string which is the stringified representation of a json array containing the version number as string. Ugly but it just works*. (Trust Me Bro™)

*actually tested on a private repo