### PR TITLE
Initial version of Pmod SSR driver with basic on/off control via GPIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- New pmod_ssr driver
+
 ## [2.6.0] - 2024-07-29
 
 ### Fixed
 
- - Fix barebox error handling [grisp/#137](https://github.com/grisp/grisp/pull/137)
- - Fix the commands available in RTEMS shell [grisp/#132](https://github.com/grisp/grisp/pull/132)
- 
+- Fix barebox error handling [grisp/#137](https://github.com/grisp/grisp/pull/137)
+- Fix the commands available in RTEMS shell [grisp/#132](https://github.com/grisp/grisp/pull/132)
+
 ### Added
 
- - Expose emulation status through grisp.hrl macro ?IS_EMULATED [grisp/#137](https://github.com/grisp/grisp/pull/137)
- - Copy configuration files to /etc during boot [grisp/#132](https://github.com/grisp/grisp/pull/132)
- - Add default configuration for DNS support [grisp/#132](https://github.com/grisp/grisp/pull/132)
- - Add RTEMS log priority option in INI file [grisp/#132](https://github.com/grisp/grisp/pull/132)
+- Expose emulation status through grisp.hrl macro ?IS_EMULATED [grisp/#137](https://github.com/grisp/grisp/pull/137)
+- Copy configuration files to /etc during boot [grisp/#132](https://github.com/grisp/grisp/pull/132)
+- Add default configuration for DNS support [grisp/#132](https://github.com/grisp/grisp/pull/132)
+- Add RTEMS log priority option in INI file [grisp/#132](https://github.com/grisp/grisp/pull/132)
 
 ## [2.5.0] - 2024-06-25
 
 ### Added - Remove ssl patch for OTP-26 builds
+
 [grisp/#127](https://github.com/grisp/grisp/pull/127) - Add support for OTP 27
 [grisp/#130](https://github.com/grisp/grisp/pull/130) - Add support for OTP 26.2
 [grisp/#131](https://github.com/grisp/grisp/pull/131)
@@ -68,8 +73,8 @@ and this project adheres to
 
 ## [2.0.0] - 2022-02-01
 
-***Note! This release is not compatible with GRiSP 1 yet!** GRiSP 1
-   compatibility will get added in a later patch release.*
+**\*Note! This release is not compatible with GRiSP 1 yet!** GRiSP 1
+compatibility will get added in a later patch release.\*
 
 ### Added
 
@@ -102,16 +107,18 @@ and this project adheres to
 
 ### Added
 
-* Add link to totorial to Pmod NAV doc [\#59](https://github.com/grisp/grisp/issues/59)
-* Add documentation [\#71](https://github.com/grisp/grisp/pull/71) ([maehjam](https://github.com/maehjam))
-- Add documentation [\#68](https://github.com/grisp/grisp/pull/68) ([maehjam](https://github.com/maehjam))
-- Add documentation for PmodNAV [\#67](https://github.com/grisp/grisp/pull/67) ([maehjam](https://github.com/maehjam))
+- Add link to totorial to Pmod NAV doc [\#59](https://github.com/grisp/grisp/issues/59)
+- Add documentation [\#71](https://github.com/grisp/grisp/pull/71) ([maehjam](https://github.com/maehjam))
+
+* Add documentation [\#68](https://github.com/grisp/grisp/pull/68) ([maehjam](https://github.com/maehjam))
+* Add documentation for PmodNAV [\#67](https://github.com/grisp/grisp/pull/67) ([maehjam](https://github.com/maehjam))
 
 ### Fixed
 
-* add\_device fails for PmodHYGRO [\#69](https://github.com/grisp/grisp/issues/69)
-- Fix for add\_device, fix of read message, add documentation [\#70](https://github.com/grisp/grisp/pull/70) ([maehjam](https://github.com/maehjam))
-- Fix edoc syntax [\#66](https://github.com/grisp/grisp/pull/66) ([nextl00p](https://github.com/nextl00p))
+- add_device fails for PmodHYGRO [\#69](https://github.com/grisp/grisp/issues/69)
+
+* Fix for add_device, fix of read message, add documentation [\#70](https://github.com/grisp/grisp/pull/70) ([maehjam](https://github.com/maehjam))
+* Fix edoc syntax [\#66](https://github.com/grisp/grisp/pull/66) ([nextl00p](https://github.com/nextl00p))
 
 ## [1.1.6] - 2019-09-27
 
@@ -123,25 +130,26 @@ and this project adheres to
 
 ### Added
 
-* Make it possible to configure UART pins as GPIO [\#37](https://github.com/grisp/grisp/issues/37)
-* Implement read command for pmod\_gyro [\#61](https://github.com/grisp/grisp/pull/61) ([GalaxyGorilla](https://github.com/GalaxyGorilla))
-* Gps [\#57](https://github.com/grisp/grisp/pull/57) ([aytchell](https://github.com/aytchell))
-* Add support for OTP 22 [\#54](https://github.com/grisp/grisp/pull/54) ([sylane](https://github.com/sylane))
-* Add missing SPI pins [\#56](https://github.com/grisp/grisp/pull/56) ([Theuns-Botha](https://github.com/Theuns-Botha))
-* Examples for grisp\_led:pattern/2 using functions [\#50](https://github.com/grisp/grisp/pull/50) ([Laymer](https://github.com/Laymer))
-* Add Feature wireless ad hoc network mode [\#41](https://github.com/grisp/grisp/pull/41) ([Laymer](https://github.com/Laymer))
-*  Add Digilent Pmod\_ALS ambient light sensor driver.  [\#40](https://github.com/grisp/grisp/pull/40) ([Laymer](https://github.com/Laymer))
-* Add pmod hygro driver [\#31](https://github.com/grisp/grisp/pull/31) ([sebb7](https://github.com/sebb7))
+- Make it possible to configure UART pins as GPIO [\#37](https://github.com/grisp/grisp/issues/37)
+- Implement read command for pmod_gyro [\#61](https://github.com/grisp/grisp/pull/61) ([GalaxyGorilla](https://github.com/GalaxyGorilla))
+- Gps [\#57](https://github.com/grisp/grisp/pull/57) ([aytchell](https://github.com/aytchell))
+- Add support for OTP 22 [\#54](https://github.com/grisp/grisp/pull/54) ([sylane](https://github.com/sylane))
+- Add missing SPI pins [\#56](https://github.com/grisp/grisp/pull/56) ([Theuns-Botha](https://github.com/Theuns-Botha))
+- Examples for grisp_led:pattern/2 using functions [\#50](https://github.com/grisp/grisp/pull/50) ([Laymer](https://github.com/Laymer))
+- Add Feature wireless ad hoc network mode [\#41](https://github.com/grisp/grisp/pull/41) ([Laymer](https://github.com/Laymer))
+- Add Digilent Pmod_ALS ambient light sensor driver. [\#40](https://github.com/grisp/grisp/pull/40) ([Laymer](https://github.com/Laymer))
+- Add pmod hygro driver [\#31](https://github.com/grisp/grisp/pull/31) ([sebb7](https://github.com/sebb7))
 
 ### Fixed
 
-* Edoc doesn't build on master [\#60](https://github.com/grisp/grisp/issues/60)
-* grisp\_led:pattern documentation is missing the Fun argument [\#49](https://github.com/grisp/grisp/issues/49)
-* Data decoding for pmod\_maxsonar is wrong [\#42](https://github.com/grisp/grisp/issues/42)
-* Quickfix for typo [\#64](https://github.com/grisp/grisp/pull/64) ([Laymer](https://github.com/Laymer))
-- Quickfix decoding pattern [\#51](https://github.com/grisp/grisp/pull/51) ([Laymer](https://github.com/Laymer))
-- Split out emulation layer [\#46](https://github.com/grisp/grisp/pull/46) ([Theuns-Botha](https://github.com/Theuns-Botha))
-- Fixed data decoding for 'Digilent PmodMAXSONAR' [\#43](https://github.com/grisp/grisp/pull/43) ([aytchell](https://github.com/aytchell))
+- Edoc doesn't build on master [\#60](https://github.com/grisp/grisp/issues/60)
+- grisp_led:pattern documentation is missing the Fun argument [\#49](https://github.com/grisp/grisp/issues/49)
+- Data decoding for pmod_maxsonar is wrong [\#42](https://github.com/grisp/grisp/issues/42)
+- Quickfix for typo [\#64](https://github.com/grisp/grisp/pull/64) ([Laymer](https://github.com/Laymer))
+
+* Quickfix decoding pattern [\#51](https://github.com/grisp/grisp/pull/51) ([Laymer](https://github.com/Laymer))
+* Split out emulation layer [\#46](https://github.com/grisp/grisp/pull/46) ([Theuns-Botha](https://github.com/Theuns-Botha))
+* Fixed data decoding for 'Digilent PmodMAXSONAR' [\#43](https://github.com/grisp/grisp/pull/43) ([aytchell](https://github.com/aytchell))
 
 ## [1.1.4] - 2018-07-30
 
@@ -153,78 +161,77 @@ and this project adheres to
 
 ### Changed
 
-* Make embedded mode the default [\#34](https://github.com/grisp/grisp/pull/34) ([nextl00p](https://github.com/nextl00p))
+- Make embedded mode the default [\#34](https://github.com/grisp/grisp/pull/34) ([nextl00p](https://github.com/nextl00p))
 
 ### Fixed
 
-* erlang:get\_stacktrace/0 is deprecated in OTP 21 [\#33](https://github.com/grisp/grisp/issues/33)
-* deprecated erlang:get\_stacktrace/0 function [\#36](https://github.com/grisp/grisp/pull/36) ([getong](https://github.com/getong))
+- erlang:get_stacktrace/0 is deprecated in OTP 21 [\#33](https://github.com/grisp/grisp/issues/33)
+- deprecated erlang:get_stacktrace/0 function [\#36](https://github.com/grisp/grisp/pull/36) ([getong](https://github.com/getong))
 
 ## [1.1.2] - 2018-06-21
 
-* Add support for OTP 21.0
+- Add support for OTP 21.0
 
 ## [1.1.1] - 2018-06-06
 
 ### Added
 
-* Add support for OTP 21.0-rc1 [\#27](https://github.com/grisp/grisp/pull/27) ([sylane](https://github.com/sylane))
-* \[WIP\] Update to support RTEMS 5.0 [\#26](https://github.com/grisp/grisp/pull/26) ([eproxus](https://github.com/eproxus))
+- Add support for OTP 21.0-rc1 [\#27](https://github.com/grisp/grisp/pull/27) ([sylane](https://github.com/sylane))
+- \[WIP\] Update to support RTEMS 5.0 [\#26](https://github.com/grisp/grisp/pull/26) ([eproxus](https://github.com/eproxus))
 
 ### Fixed
 
-* Start Erlang runtime when source dependencies are included [\#25](https://github.com/grisp/grisp/issues/25)
-* Writing to a file hangs the system after listing files [\#24](https://github.com/grisp/grisp/issues/24)
+- Start Erlang runtime when source dependencies are included [\#25](https://github.com/grisp/grisp/issues/25)
+- Writing to a file hangs the system after listing files [\#24](https://github.com/grisp/grisp/issues/24)
 
 ## [1.1.0] - 2018-05-24
 
 ### Added
 
-* Add support for DHCP configuration file [\#23](https://github.com/grisp/grisp/pull/23) ([sylane](https://github.com/sylane))
-* Make onewire driver concurrency safe [\#21](https://github.com/grisp/grisp/pull/21) ([eproxus](https://github.com/eproxus))
-* Add version to OTP xcomp file [\#20](https://github.com/grisp/grisp/pull/20) ([sylane](https://github.com/sylane))
-* Add board config and OTP cross-compilation config [\#18](https://github.com/grisp/grisp/pull/18) ([sylane](https://github.com/sylane))
+- Add support for DHCP configuration file [\#23](https://github.com/grisp/grisp/pull/23) ([sylane](https://github.com/sylane))
+- Make onewire driver concurrency safe [\#21](https://github.com/grisp/grisp/pull/21) ([eproxus](https://github.com/eproxus))
+- Add version to OTP xcomp file [\#20](https://github.com/grisp/grisp/pull/20) ([sylane](https://github.com/sylane))
+- Add board config and OTP cross-compilation config [\#18](https://github.com/grisp/grisp/pull/18) ([sylane](https://github.com/sylane))
 
 ## [1.0.1] - 2017-12-19
 
 ### Fixed
 
-* Can't compile sample application on Ubuntu 16.04 server [\#17](https://github.com/grisp/grisp/issues/17)
-* Ubuntu 16.04 is missing build-essential package as dependency [\#16](https://github.com/grisp/grisp/issues/16)
-* Build failing on Mac 10.10.5 [\#15](https://github.com/grisp/grisp/issues/15)
+- Can't compile sample application on Ubuntu 16.04 server [\#17](https://github.com/grisp/grisp/issues/17)
+- Ubuntu 16.04 is missing build-essential package as dependency [\#16](https://github.com/grisp/grisp/issues/16)
+- Build failing on Mac 10.10.5 [\#15](https://github.com/grisp/grisp/issues/15)
 
 ## [1.0.0] - 2017-11-17
 
 ### Fixed
 
-* grisp\_spi\_drv is no gen\_server [\#12](https://github.com/grisp/grisp/issues/12)
-* Fix display of error message during boot, even when correct hostname … [\#14](https://github.com/grisp/grisp/pull/14) ([nextl00p](https://github.com/nextl00p))
+- grisp_spi_drv is no gen_server [\#12](https://github.com/grisp/grisp/issues/12)
+- Fix display of error message during boot, even when correct hostname … [\#14](https://github.com/grisp/grisp/pull/14) ([nextl00p](https://github.com/nextl00p))
 
 ## [0.1.1] - 2017-11-08
 
 ### Fixed
 
-* Added missing files to Hex package
+- Added missing files to Hex package
 
 ## [0.1.0] - 2017-11-06
 
 ### Added
 
-* Added emulator instructions in README [\#8](https://github.com/grisp/grisp/pull/8) ([nextl00p](https://github.com/nextl00p))
-* Quickcheck: model for 3 type of crashes plus clustering [\#4](https://github.com/grisp/grisp/pull/4) ([ThomasArts](https://github.com/ThomasArts))
-* Quickcheck model for LEDs [\#1](https://github.com/grisp/grisp/pull/1) ([ThomasArts](https://github.com/ThomasArts))
+- Added emulator instructions in README [\#8](https://github.com/grisp/grisp/pull/8) ([nextl00p](https://github.com/nextl00p))
+- Quickcheck: model for 3 type of crashes plus clustering [\#4](https://github.com/grisp/grisp/pull/4) ([ThomasArts](https://github.com/ThomasArts))
+- Quickcheck model for LEDs [\#1](https://github.com/grisp/grisp/pull/1) ([ThomasArts](https://github.com/ThomasArts))
 
 ### Changed
 
-* Raw refactoring of onewire interface [\#6](https://github.com/grisp/grisp/pull/6) ([ThomasArts](https://github.com/ThomasArts))
+- Raw refactoring of onewire interface [\#6](https://github.com/grisp/grisp/pull/6) ([ThomasArts](https://github.com/ThomasArts))
 
 ### Fixed
 
-* Supervision restart strategies [\#3](https://github.com/grisp/grisp/issues/3)
-* grisp\_led is accepting interval 0 \(as well as negative intervals\) [\#2](https://github.com/grisp/grisp/issues/2)
-* Fixed wrong registers in rotation vector [\#9](https://github.com/grisp/grisp/pull/9) ([nextl00p](https://github.com/nextl00p))
-* Fix for \#2. Negative intervals are now treated by turning off leds [\#5](https://github.com/grisp/grisp/pull/5) ([nextl00p](https://github.com/nextl00p))
-
+- Supervision restart strategies [\#3](https://github.com/grisp/grisp/issues/3)
+- grisp_led is accepting interval 0 \(as well as negative intervals\) [\#2](https://github.com/grisp/grisp/issues/2)
+- Fixed wrong registers in rotation vector [\#9](https://github.com/grisp/grisp/pull/9) ([nextl00p](https://github.com/nextl00p))
+- Fix for \#2. Negative intervals are now treated by turning off leds [\#5](https://github.com/grisp/grisp/pull/5) ([nextl00p](https://github.com/nextl00p))
 
 [Unreleased]: https://github.com/grisp/grisp/compare/2.6.0...HEAD
 [2.6.0]: https://github.com/grisp/grisp/compare/2.5.0...2.6.0

--- a/src/pmod_ssr.erl
+++ b/src/pmod_ssr.erl
@@ -73,7 +73,6 @@ init(Slot) ->
     % TODO: expand for more possible Slots
     case {grisp_hw:platform(), Slot} of
         {_, gpio1} -> ok;
-        {grisp_base, gpio2} -> ok;
         {P, S} -> error({incompatible_slot, P, S})
     end,
     Pin1 = grisp_gpio:open(gpio1_1, #{mode => {output, 0}}),

--- a/src/pmod_ssr.erl
+++ b/src/pmod_ssr.erl
@@ -1,0 +1,115 @@
+% @doc
+% <a href="https://digilent.com/reference/pmod/pmodssr/reference-manual">
+% PmodSSR</a>
+% module.
+%
+% The Pmod SSR (Solid State Relay) module is designed to control high-power devices using a GPIO pin from a GRiSP board.
+%
+% Pin 1: ON/OFF control (connected to GPIO).
+% Pin 5: Ground (GND).
+% Pin 6: 3.3V Power Supply (VCC).
+%
+% This relay can be switched on or off by sending a control signal through a single GPIO pin (minimal setup needed for controlling high-power loads).
+% The driver allows you to easily turn the relay on and off through simple commands.
+%
+%
+% Start the driver with
+% ```
+% 1> grisp:add_device(gpio1, pmod_ssr).
+% '''
+% @end
+-module(pmod_ssr).
+
+-behaviour(gen_server).
+
+-include("grisp_internal.hrl").
+%--- Exports -------------------------------------------------------------------
+
+% API
+-export([start_link/2]).
+-export([on/0]).
+-export([off/0]).
+
+% Callbacks
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+
+
+%--- API -----------------------------------------------------------------------
+
+% @private
+start_link(Slot, _Opts) ->
+    gen_server:start_link(?MODULE, Slot, []).
+
+% @doc Turn the relay on and off.
+%
+% === Examples ===
+% To turn on, use:
+% ```
+% 2> pmod_ssr:on().
+% ok
+% '''
+% To turn back off, use:
+% ```
+% 3> pmod_ssr:off().
+% ok
+% '''
+
+-spec on() -> any() | {error, any()}.
+on() ->
+    call(on).
+
+-spec off() -> any() | {error, any()}.
+off() ->
+    call(off).
+
+
+%--- Callbacks -----------------------------------------------------------------
+
+% @private
+init(Slot) ->
+    % TODO: expand for more possible Slots
+    case {grisp_hw:platform(), Slot} of
+        {grisp_base, gpio1} -> ok;
+        {grisp2, gpio1} -> ok;
+        {P, S} -> error({incompatible_slot, P, S})
+    end,
+    Pin1 = grisp_gpio:open(gpio1_1, #{mode => {output, 0}}),
+    process_flag(trap_exit, true),
+    grisp_devices:register(Slot, ?MODULE),
+    {ok, #{pin => Pin1}}.
+
+% @private
+handle_call(Call, _From, State) ->
+    try execute_call(Call, State)
+        catch throw:Reason -> {reply, {error, Reason}, State}
+    end.
+
+% @private
+handle_cast(Request, _State) -> error({unknown_cast, Request}).
+
+% @private
+handle_info(_Any, State) ->
+    {noreply, State}.
+
+
+%--- Internal ------------------------------------------------------------------
+
+call(Call) ->
+    Dev = grisp_devices:default(?MODULE),
+    case gen_server:call(Dev#device.pid, Call) of
+        {error, Reason} -> error(Reason);
+        Result          -> Result
+    end.
+
+execute_call(on, #{pin := Pin} = State) ->
+    {reply, set(Pin, 1), State};
+execute_call(off, #{pin := Pin} = State) ->
+    {reply, set(Pin, 0), State};
+execute_call(Request, _State) ->
+    error({unknown_call, Request}).
+
+set(Pin, Value) ->
+    grisp_gpio:set(Pin, Value).

--- a/src/pmod_ssr.erl
+++ b/src/pmod_ssr.erl
@@ -57,11 +57,11 @@ start_link(Slot, _Opts) ->
 % ok
 % '''
 
--spec on() -> any() | {error, any()}.
+-spec on() -> ok | {error, any()}.
 on() ->
     call(on).
 
--spec off() -> any() | {error, any()}.
+-spec off() -> ok | {error, any()}.
 off() ->
     call(off).
 
@@ -72,8 +72,8 @@ off() ->
 init(Slot) ->
     % TODO: expand for more possible Slots
     case {grisp_hw:platform(), Slot} of
-        {grisp_base, gpio1} -> ok;
-        {grisp2, gpio1} -> ok;
+        {_, gpio1} -> ok;
+        {grisp_base, gpio2} -> ok;
         {P, S} -> error({incompatible_slot, P, S})
     end,
     Pin1 = grisp_gpio:open(gpio1_1, #{mode => {output, 0}}),


### PR DESCRIPTION
This PR introduces the initial version of the Pmod SSR (Solid State Relay) driver for GRiSP boards (`grisp-base` and `grisp2`). The driver enables control of a solid-state relay using a single GPIO pin by switching the relay on `pmod_ssr:on/0` and off `pmod_ssr:off/0`.

Here you can find the Pmod [reference manual](https://digilent.com/reference/pmod/pmodssr/reference-manual)