### PR TITLE
Update check_otp_rel.yaml

### DIFF
--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Initialize Cached version
         if: steps.version-cache.outputs.cache-hit != 'true'
         run: |
-          cp last_seen_ver.txt > last_cached_ver.txt
+          cp last_seen_ver.txt last_cached_ver.txt
       - name: Compare with Latest Release Number
         id: compare-vsn
         continue-on-error: true

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: last_cached_ver.txt
           key: ${{env.cache-name}}
-      - name: Cache latest version
+      - name: Initialize Cached version
         if: steps.version-cache.outputs.cache-hit != 'true'
         run: |
           cp last_seen_ver.txt > last_cached_ver.txt
@@ -29,6 +29,9 @@ jobs:
         continue-on-error: true
         run: |
           diff last_cached_ver.txt last_seen_ver.txt
+      - name: Update cached Version
+        run: |
+          cp last_seen_ver.txt last_cached_ver.txt
       - name: Trigger OTP package build
         if: ${{ steps.compare-vsn.outcome == 'failure' }}
         run: |

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -9,6 +9,10 @@ jobs:
   check-otp:
     runs-on: ubuntu-latest
     steps:
+      - name: Get latest version
+        run: |
+          curl -sL https://api.github.com/repos/erlang/otp/releases/latest | \
+          jq -r ".tag_name" > last_seen_ver.txt
       - uses: actions/cache@v4
         id: version-cache
         env:
@@ -19,14 +23,11 @@ jobs:
       - name: Cache latest version
         if: steps.version-cache.outputs.cache-hit != 'true'
         run: |
-          curl -sL https://api.github.com/repos/erlang/otp/releases/latest | \
-          jq -r ".tag_name" > last_cached_ver.txt
+          cp last_seen_ver.txt > last_cached_ver.txt
       - name: Compare with Latest Release Number
         id: compare-vsn
         continue-on-error: true
         run: |
-          curl -sL https://api.github.com/repos/erlang/otp/releases/latest | \
-          jq -r ".tag_name" > last_seen_ver.txt
           diff last_cached_ver.txt last_seen_ver.txt
       - name: Trigger OTP package build
         if: ${{ steps.compare-vsn.outcome == 'failure' }}


### PR DESCRIPTION
The current CI cron job never updates the cached version if there is a cache it.
The version was stuck at 27.0.1 and this caused to trigger the next workflow every hour.

These changes make sure the cached version is always updated to the last version after the diff comparison.