### PR TITLE
Add issue trigger to otp_pkg.yaml

### DIFF
--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -77,6 +77,15 @@ jobs:
           rebar3 grisp build --tar
           PKG_NAME=$(ls _grisp/grisp2/otp/${{matrix.otp}}/package)
           echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+      - name: Create GitHub Issue
+        if: ${{ steps.build.outcome == 'failure' }}
+        run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/grisp/grisp/issues \
+            -d '{"title":"Failed package build for OTP-${{matrix.otp}}","body":"Prebuilt package build failed:\n OTP Version: ${{matrix.otp}}\n Applications: [${{matrix.deps}}]\nWorkflow Run: https://github.com/grisp/grisp/actions/runs/${{github.run_id}}", "labels":["otp-build"]}'
       - name: Deploy test
         if: ${{ steps.build.outcome == 'success' }}
         id: deploy-test


### PR DESCRIPTION
The failure of the build step will generate an issue that contains relevant informations and a link to the workflow run to inspect logs.