### PR TITLE
Announce new packages in private company slack

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,8 @@
 # Manually trigger OTP package generation
 
 Here is a quick example with the GitHub CLI, for more info refer to the [docs](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event).
-You can do this whenever you see we are missing one or more releases, you can pass multiple versions in the list.
+You can do this whenever you see we are missing one release.
+You need to call this multiple times to target different OTP releases.
 
 ```shell
 gh api \
@@ -10,7 +11,7 @@ gh api \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   /repos/grisp/grisp/dispatches \
   -f "event_type=new-otp-release" \
-  -F "client_payload[otp]=[\\\"27.0\\\", \\\"26.2.5.1\\\"]" \
+  -F "client_payload[otp]=\\\"27.1.2\\\"" \
   -F "client_payload[unit]=false" \
   -F "client_payload[integration]=true"
 ```

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -38,4 +38,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             https://api.github.com/repos/grisp/grisp/dispatches \
-            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"[\\\\\\\"${OTP}\\\\\\\"]\",\"unit\":false,\"integration\":true}}"
+            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"\\\\\\\"${OTP}\\\\\\\"\",\"unit\":false,\"integration\":true}}"

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -136,7 +136,6 @@ jobs:
           echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
       - name: Download Package Artifact
         id: artifact-download
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ${{env.pkg_name}}
@@ -151,7 +150,6 @@ jobs:
           ./aws/install
           aws --version
       - name: Upload to S3
-        id: s3
         if: ${{ steps.artifact-download.outcome == 'success' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -31,6 +31,8 @@ jobs:
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
       fail-fast: false
+    outputs:
+      result: ${{ steps.report.outputs.result }}
     steps:
       - name: Install AWS CLI
         run: |
@@ -100,6 +102,7 @@ jobs:
           name: ${{env.pkg_name}}
           path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
       - name: Upload to S3
+        id: s3
         if: ${{ steps.deploy-test.outcome == 'success' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
@@ -109,12 +112,18 @@ jobs:
           aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
           robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
           s3://grisp/platforms/grisp2/otp/
-  slack-notifications:
+      - name: Report result
+        id: report
+        if: ${{ steps.s3.outcome == 'success' }}
+        run: |
+          echo 'result=new_package' >> "$GITHUB_OUTPUT"
+  slack-message:
     runs-on: ubuntu-latest
     needs: [define-matrix, otp-gen-matrix]
+    if: needs.otp-gen-matrix.outputs.result == 'new_package'
     steps:
     - name: Stritzinger Slack Notification
       run: |
         curl  ${{secrets.STRITZINGER_SLACK_WEBHOOK}} \
           -H "Content-Type: application/json; charset=utf-8" \
-          -d '{"otp":"${{ needs.define-matrix.outputs.otp-version }}"}'
+          -d '{"otp":${{ needs.define-matrix.outputs.otp-version }}}'

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -32,7 +32,7 @@ jobs:
         rebar3: ['3']
       fail-fast: false
     outputs:
-      result: ${{ steps.report.outputs.result }}
+      report: ${{ steps.report.outputs.report }}
     steps:
       - name: Install AWS CLI
         run: |
@@ -116,11 +116,11 @@ jobs:
         id: report
         if: ${{ steps.s3.outcome == 'success' }}
         run: |
-          echo 'result=new_package' >> "$GITHUB_OUTPUT"
+          echo 'report=new_package' >> "$GITHUB_OUTPUT"
   slack-message:
     runs-on: ubuntu-latest
     needs: [define-matrix, otp-gen-matrix]
-    if: needs.otp-gen-matrix.outputs.result == 'new_package'
+    if: needs.otp-gen-matrix.outputs.report == 'new_package'
     steps:
     - name: Stritzinger Slack Notification
       run: |

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -27,7 +27,7 @@ jobs:
         ImageOS: 'ubuntu22'
     strategy:
       matrix:
-        otp: ${{ fromJson(needs.define-matrix.outputs.otp-versions) }}
+        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-versions) }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
       fail-fast: false

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -34,14 +34,6 @@ jobs:
     outputs:
       report: ${{ steps.report.outputs.report }}
     steps:
-      - name: Install AWS CLI
-        run: |
-          apt update
-          apt install curl unzip -y
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          ./aws/install
-          aws --version
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -72,6 +64,7 @@ jobs:
         id: build
         if: ${{ steps.deploy.outcome == 'failure' }}
         working-directory: robot
+        continue-on-error: true
         run: |
           sed -i '/{grisp, \[/a\
           '"{build, [{toolchain, [{directory, \"/grisp2-rtems-toolchain\"}]}]}," rebar.config
@@ -88,6 +81,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/grisp/grisp/issues \
             -d '{"title":"Failed package build for OTP-${{matrix.otp}}","body":"Prebuilt package build failed:\n OTP Version: ${{matrix.otp}}\n Applications: [${{matrix.deps}}]\nWorkflow Run: https://github.com/grisp/grisp/actions/runs/${{github.run_id}}", "labels":["otp-build"]}'
+            exit 1
       - name: Deploy test
         if: ${{ steps.build.outcome == 'success' }}
         id: deploy-test
@@ -101,9 +95,64 @@ jobs:
         with:
           name: ${{env.pkg_name}}
           path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
+  upload_artifacts:
+    runs-on: ubuntu-latest
+    needs: [define-matrix, otp-gen-matrix]
+    strategy:
+      matrix:
+        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
+        deps: ['grisp', 'grisp, grisp_cryptoauth']
+        rebar3: ['3']
+    outputs:
+      artifacts: ${{ steps.matrix-def.outputs.otp-version }}
+    steps:
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{ matrix.rebar3 }}
+      - name: Install GRiSP Plugin
+        run: |
+          mkdir -p ${HOME}/.config/rebar3/
+          echo "{plugins, [rebar3_hex,rebar3_grisp]}." > ${HOME}/.config/rebar3/rebar.config
+          rebar3
+      - name: Generate Dummy Project
+        run: |
+          rebar3 grisp configure -i false --otp_version="=${{matrix.otp}}" --dest="_deploy"
+          mkdir robot/_deploy
+          sed -i 's/grisp/${{matrix.deps}}/g' robot/src/robot.app.src
+          sed -i '/{deps, \[/,/\]}.*/{
+          N
+          N
+          s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
+          }' robot/rebar.config
+          cat robot/rebar.config
+      - name: Get Package Name
+        id: deploy
+        working-directory: robot
+        run: |
+          rebar3 grisp report
+          PKG_HASH=grep -o '<<"[0-9a-f]\{64\}">>' _grisp/report/hash.txt | tail -n 1 | sed 's/[<">]//g'
+          PKG_NAME=grisp_otp_build_${{matrix.otp}}_${{env.pkg_hash}}.tar.gz
+          echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
+      - name: Download Package Artifact
+        id: artifact-download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.pkg_name}}
+          path: ${{env.pkg_name}}
+      - name: Install AWS CLI
+        if: ${{ steps.artifact-download.outcome == 'success' }}
+        run: |
+          apt update
+          apt install curl unzip -y
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          aws --version
       - name: Upload to S3
         id: s3
-        if: ${{ steps.deploy-test.outcome == 'success' }}
+        if: ${{ steps.artifact-download.outcome == 'success' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}
@@ -112,15 +161,9 @@ jobs:
           aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
           robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
           s3://grisp/platforms/grisp2/otp/
-      - name: Report result
-        id: report
-        if: ${{ steps.s3.outcome == 'success' }}
-        run: |
-          echo 'report=new_package' >> "$GITHUB_OUTPUT"
   slack-message:
     runs-on: ubuntu-latest
-    needs: [define-matrix, otp-gen-matrix]
-    if: needs.otp-gen-matrix.outputs.report == 'new_package'
+    needs: [define-matrix, otp-gen-matrix, upload_artifacts]
     steps:
     - name: Stritzinger Slack Notification
       run: |

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -9,7 +9,7 @@ jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
-      otp-versions: ${{ steps.matrix-def.outputs.otp-versions }}
+      otp-version: ${{ steps.matrix-def.outputs.otp-version }}
     steps:
       - name: Matrix Definition
         id: matrix-def

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Matrix Definition
         id: matrix-def
         run: |
-           echo "otp-versions=${{ github.event.client_payload.otp }}" >> "$GITHUB_OUTPUT"
+           echo "otp-version=${{ github.event.client_payload.otp }}" >> "$GITHUB_OUTPUT"
   otp-gen-matrix:
     runs-on: ubuntu-latest
     needs: define-matrix
@@ -27,7 +27,7 @@ jobs:
         ImageOS: 'ubuntu22'
     strategy:
       matrix:
-        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-versions) }}"]
+        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
       fail-fast: false
@@ -99,7 +99,6 @@ jobs:
         with:
           name: ${{env.pkg_name}}
           path: robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}}
-
       - name: Upload to S3
         if: ${{ steps.deploy-test.outcome == 'success' }}
         env:
@@ -110,3 +109,12 @@ jobs:
           aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
           robot/_grisp/grisp2/otp/${{matrix.otp}}/package/${{env.pkg_name}} \
           s3://grisp/platforms/grisp2/otp/
+  slack-notifications:
+    runs-on: ubuntu-latest
+    needs: [define-matrix, otp-gen-matrix]
+    steps:
+    - name: Stritzinger Slack Notification
+      run: |
+        curl  ${{secrets.STRITZINGER_SLACK_WEBHOOK}} \
+          -H "Content-Type: application/json; charset=utf-8" \
+          -d '{"otp":"${{ needs.define-matrix.outputs.otp-version }}"}'

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -132,7 +132,7 @@ jobs:
         run: |
           rebar3 grisp report
           PKG_HASH=grep -o '<<"[0-9a-f]\{64\}">>' _grisp/report/hash.txt | tail -n 1 | sed 's/[<">]//g'
-          PKG_NAME=grisp_otp_build_${{matrix.otp}}_${{env.pkg_hash}}.tar.gz
+          PKG_NAME=grisp_otp_build_${{matrix.otp}}_${PKG_HASH}.tar.gz
           echo "pkg_name=$PKG_NAME" >> $GITHUB_ENV
       - name: Download Package Artifact
         id: artifact-download


### PR DESCRIPTION
I tested in another repo and a private slack channel, this should work.

New JOBS Logic

1. Parallel build of all packages covering a single OTP release with latest grisp deps combos.
2. Every failing build step will generate a github issue with a link to the failing workflow run 
3. We upload all expected packages on S3, this will succeed only if all expected the artifacts exists
4. Publish a slack message only if the "upload" matrix succeeded in uploading new packages

In this way we avoid uploading partial support to an OTP release if we have a failing package.
At the same time we make sure we do not announce any partial change but only full updates that cover all matrix combinations and are uploaded successfully.