### PR TITLE
Fix Edoc and add check In CI

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -52,3 +52,6 @@ jobs:
 
       - name: Analyze
         run: rebar3 dialyzer
+
+      - name: Edoc
+        run: rebar3 edoc

--- a/src/grisp_info.erl
+++ b/src/grisp_info.erl
@@ -1,7 +1,7 @@
 % @doc GRiSP general information.
 %
 % When running grisp on a host machine during development, the functions return:
-% 
+%
 % ```
 % 1> grisp_info:hardware().
 % #{
@@ -36,7 +36,7 @@
 %     {rtems, [{version, <<"5">>}]},
 %     {otp, [{version, <<"26.2.5.4">>}]}
 % ]}.
-% ```
+% '''
 %
 % @end
 -module(grisp_info).
@@ -187,10 +187,10 @@ hardware_info() ->
         pcb_variant => PcbVariant,
         pcb_version => list_to_binary(PcbVersionStr),
         prod_date => ProdDate
-    }.    
+    }.
 
 software_info() ->
-    software_info(boot_source()).    
+    software_info(boot_source()).
 
 software_info(Source) ->
     Root = boot_root(Source),

--- a/src/grisp_info.erl
+++ b/src/grisp_info.erl
@@ -22,7 +22,7 @@
 % '''
 %
 % For grisp_info:software() to be defined during local development, a term file
-% named `MANIFEST` must exists in the current directory and looks like:
+% named `MANIFEST' must exists in the current directory and looks like:
 %
 % ```
 % %% coding: utf-8


### PR DESCRIPTION
We broke Edoc in a past commit, this fixes it and makes sure we always build edoc in CI to avoid breaking it again by error.