### PR TITLE
Fix assets path in 2 images

### DIFF
--- a/src/grisp_gpio.erl
+++ b/src/grisp_gpio.erl
@@ -100,7 +100,7 @@ pin (see [Figure 1](#figure_1)).
 ### PMOD Pin Numbers
 
 <a name="figure_1"/>
-<img src="../assets/pin_mapping.svg" style="width: 700px;">
+<img src="assets/pin_mapping.svg" style="width: 700px;">
 Figure 1. PMOD connectors as seen from the side of a GRiSP board with number mappings
 
 PMOD Type A consists of:

--- a/src/grisp_pwm.erl
+++ b/src/grisp_pwm.erl
@@ -31,7 +31,7 @@ If you want to stop using PWM on this pin you can call:
 ```
 
 <a name="figure_1"/>
-![image](../assets/pwm_example.png)
+![image](assets/pwm_example.png)
 Figure 1. Oscilloscope trace with a 0.75 % duty cycle and the default configuration.
 
 <!-- tabs-open -->


### PR DESCRIPTION
This was breaking the image loading on hex.pm

pin_mapping.svg and pwm_example.svg could not load.

I already updated the online docs.