### PR TITLE
Fix duplicated logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p>
-  <a href="#readme">
-    <img src="assets/GRiSP_Logotype_negative.svg#gh-dark-mode-only" alt="GRiSP Logo">
-    <img src="assets/GRiSP_Logotype_positive.svg#gh-light-mode-only" alt="GRiSP Logo">
-  </a>
+  <picture href="#readme">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/GRiSP_Logotype_negative.svg">
+    <img src="assets/GRiSP_Logotype_positive.svg" alt="GRiSP Logo">
+  </picture>
 </p>
 
 <p align="center">


### PR DESCRIPTION
#gh-dark-mode-only is broken

(prefers-color-scheme: dark) is the supported method

But we have a problem: the Ex Doc documentation is not handling (prefers-color-scheme: dark) correctly
