### PR TITLE
Add support for OTP-27.3

### DIFF
--- a/grisp/default/27.3/build/patches/00100-rtems.patch
+++ b/grisp/default/27.3/build/patches/00100-rtems.patch
@@ -1,0 +1,1592 @@
+diff --git a/.gitignore b/.gitignore
+index a9d88a7bf9..70305bfa7d 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -52,6 +52,11 @@ x86_64-unknown-freebsd[0-9]*.[0-9]*
+ x86_64-unknown-openbsd[0-9]*.[0-9]*
+ powerpc-unknown-linux-gnu
+ aarch64-unknown-linux-gnu
++arm-unknown-rtems[0-9]*.[0-9]*
++powerpc-unknown-rtems[0-9]*.[0-9]*
++
++# Compilation/linking artifacts
++linker.map
+ 
+ # Mac OS X
+ a.out.dSYM/
+diff --git a/Makefile.in b/Makefile.in
+index ec5988348c..778d8d20af 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -851,7 +851,11 @@ $(TEST_DIRS):
+ #
+ # Order is important here, don't change it!
+ #
++ifeq ($(findstring rtems,$(TARGET)),rtems)
++INST_DEP += install.dirs install.emulator install.libs install.Install install.otp_version
++else
+ INST_DEP += install.dirs install.emulator install.libs install.Install install.otp_version install.bin
++endif
+ 
+ install: $(INST_DEP)
+ 
+diff --git a/erts/Makefile b/erts/Makefile
+index 3957990a3a..5a47d7609d 100644
+--- a/erts/Makefile
++++ b/erts/Makefile
+@@ -27,7 +27,11 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
+ # ----------------------------------------------------------------------
+ 
+ # Other erts dirs than the emulator dir...
++ifeq ($(findstring rtems, $(TARGET)), rtems)
++ERTSDIRS = etc lib_src
++else
+ ERTSDIRS = etc epmd lib_src
++endif
+ XINSTDIRS = preloaded
+ ifeq ($(NO_START_SCRIPTS),)
+ ERTSDIRS += start_scripts
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+index e93f052d75..2f8eee6eed 100644
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -480,8 +480,10 @@ endif
+ 
+ UNIX_ONLY_BUILDS =
+ ifeq ($(ERLANG_OSTYPE), unix)
++ifneq ($(findstring rtems, $(TARGET)), rtems)
+ UNIX_ONLY_BUILDS =	$(BINDIR)/$(CS_EXECUTABLE)
+ endif
++endif
+ 
+ .PHONY: all
+ ifdef VOID_EMULATOR
+@@ -552,9 +554,11 @@ ifeq ($(RELEASE_LIBBEAM),yes)
+ 	$(INSTALL_PROGRAM) $(BINDIR)/$(EMULATOR_LIB) "$(RELSYSDIR)/lib"
+ endif
+ ifeq ($(ERLANG_OSTYPE), unix)
++ifneq ($(findstring rtems, $(TARGET)), rtems)
+ 	$(INSTALL_PROGRAM) $(BINDIR)/$(CS_EXECUTABLE) "$(RELSYSDIR)/bin"
+ endif
+ endif
++endif
+ 
+ .PHONY: release_docs_spec
+ release_docs_spec:
+diff --git a/erts/emulator/beam/io.c b/erts/emulator/beam/io.c
+index d8653e30a5..6561fdd780 100644
+--- a/erts/emulator/beam/io.c
++++ b/erts/emulator/beam/io.c
+@@ -3022,7 +3022,7 @@ void erts_init_io(int port_tab_size,
+ 
+     init_driver(&fd_driver, &fd_driver_entry, NULL);
+     init_driver(&spawn_driver, &spawn_driver_entry, NULL);
+-#ifndef __WIN32__
++#if !(defined(__WIN32__) || defined(__rtems__))
+     init_driver(&forker_driver, &forker_driver_entry, NULL);
+ #endif
+     erts_init_static_drivers();
+diff --git a/erts/emulator/beam/sys.h b/erts/emulator/beam/sys.h
+index f90b9bfe66..63cf65934b 100644
+--- a/erts/emulator/beam/sys.h
++++ b/erts/emulator/beam/sys.h
+@@ -182,7 +182,7 @@ typedef ERTS_SYS_FD_TYPE ErtsSysFdType;
+ #if (defined(__APPLE__) && defined(__MACH__)) || defined(__DARWIN__)
+ #  define ERTS_WRITE_UNLIKELY(X) X __attribute__ ((section ("__DATA,ERTS_LOW_WRITE") ))
+ #else
+-#  define ERTS_WRITE_UNLIKELY(X) X __attribute__ ((section ("ERTS_LOW_WRITE") ))
++#  define ERTS_WRITE_UNLIKELY(X) X __attribute__ ((section (".data.read_mostly") ))
+ #endif
+ #else
+ #  define ERTS_WRITE_UNLIKELY(X) X
+diff --git a/erts/emulator/nifs/common/prim_socket_nif.c b/erts/emulator/nifs/common/prim_socket_nif.c
+index a41e3b0cd2..1a6aa283ce 100644
+--- a/erts/emulator/nifs/common/prim_socket_nif.c
++++ b/erts/emulator/nifs/common/prim_socket_nif.c
+@@ -13758,6 +13758,11 @@ int on_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+ 
+     // ESOCK_EPRINTF("\r\n[ESOCK] init IOV max\r\n");
+     data.iov_max =
++#if defined(__rtems__)
++        /* sysconf should be working on RTEMS, but for some unknown reasons
++           it returns -1 for _SC_IOV_MAX, so we hardcode the value for now */
++        1024
++#else
+ #if defined(NO_SYSCONF) || (! defined(_SC_IOV_MAX))
+ #   ifdef IOV_MAX
+         IOV_MAX
+@@ -13766,6 +13771,7 @@ int on_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+ #   endif
+ #else
+         sysconf(_SC_IOV_MAX)
++#endif
+ #endif
+         ;
+     ESOCK_ASSERT( data.iov_max > 0 );
+diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
+index ba5ba255d4..93e8fe08c9 100644
+--- a/erts/emulator/sys/unix/sys.c
++++ b/erts/emulator/sys/unix/sys.c
+@@ -516,6 +516,7 @@ erts_sys_is_area_readable(char *start, char *stop) {
+ static ERTS_INLINE int
+ prepare_crash_dump(int secs)
+ {
++#ifndef __rtems__
+ #define NUFBUF (3)
+     int i;
+     char env[21]; /* enough to hold any 64-bit integer */
+@@ -577,6 +578,9 @@ prepare_crash_dump(int secs)
+     UnUseTmpHeapNoproc(NUFBUF);
+ #undef NUFBUF
+     return has_heart;
++#else  /* __rtems__ */
++    return 0;
++#endif /* __rtems__ */
+ }
+ 
+ int erts_sys_prepare_crash_dump(int secs)
+diff --git a/erts/etc/common/Makefile.in b/erts/etc/common/Makefile.in
+index 42af9c87dc..dfc2ca3292 100644
+--- a/erts/etc/common/Makefile.in
++++ b/erts/etc/common/Makefile.in
+@@ -181,6 +181,26 @@ endif
+ PORT_ENTRY_POINT=erl_port_entry
+ ENTRY_LDFLAGS=-entry:$(PORT_ENTRY_POINT)
+ 
++else # UNIX (!win32)
++ifeq ($(findstring rtems,$(TARGET)), rtems)
++ENTRY_LDFLAGS=
++ENTRY_OBJ=
++ERLSRV_OBJECTS=
++MC_OUTPUTS=
++INET_GETHOST=$(BINDIR)/inet_gethost@EXEEXT@
++INSTALL_EMBEDDED_PROGS=
++INSTALL_EMBEDDED_DATA=../unix/start.src ../unix/start_erl.src
++INSTALL_TOP=Install
++INSTALL_TOP_BIN=
++INSTALL_MISC=
++INSTALL_SRC=
++ERLEXECDIR=
++INSTALL_LIBS=
++INSTALL_OBJS=
++INSTALL_INCLUDES=
++TEXTFILES=Install erl.src
++INSTALL_PROGS=
++
+ else
+ ENTRY_LDFLAGS=
+ ENTRY_OBJ=
+@@ -214,6 +234,7 @@ INSTALL_PROGS =              \
+ 	$(BINDIR)/$(ERLEXEC) \
+ 	$(INSTALL_EMBEDDED_PROGS)
+ endif
++endif
+ 
+ CREATE_DIRS=$(OBJDIR) $(BINDIR)
+ 
+@@ -488,11 +509,13 @@ $(BINDIR)/typer@EXEEXT@: $(OBJDIR)/typer.o $(ERTS_LIB)
+ $(OBJDIR)/typer.o: typer.c $(RC_GENERATED)
+ 	$(V_CC) $(CFLAGS) -o $@ -c typer.c
+ 
++ifneq ($(findstring rtems,$(TARGET)), rtems)
+ $(BINDIR)/escript@EXEEXT@: $(OBJDIR)/escript.o $(ERTS_LIB)
+ 	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/escript.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+ 
+ $(OBJDIR)/escript.o: escript.c $(RC_GENERATED)
+ 	$(V_CC) $(CFLAGS) -o $@ -c escript.c
++endif
+ 
+ $(BINDIR)/ct_run@EXEEXT@: $(OBJDIR)/ct_run.o $(ERTS_LIB)
+ 	$(ld_verbose) $(LD) $(LDFLAGS) -o $@ $(OBJDIR)/ct_run.o -L$(OBJDIR) $(LIBS) $(ERTS_INTERNAL_LIBS)
+diff --git a/erts/etc/unix/Install.src b/erts/etc/unix/Install.src
+index b00dd09f1a..426cd1b1f5 100644
+--- a/erts/etc/unix/Install.src
++++ b/erts/etc/unix/Install.src
+@@ -88,13 +88,34 @@ chmod 755 erl
+ 
+ cd "$ERL_ROOT/bin"
+ 
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erlc" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl_call" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/dialyzer" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/typer" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/ct_run" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/escript" .
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/erl" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/erlc" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erlc" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/erl_call" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/erl_call" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/dialyzer" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/dialyzer" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/typer" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/typer" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/ct_run" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/ct_run" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/escript" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/escript" .
++fi
+ 
+ #
+ # Set a soft link to epmd
+@@ -108,9 +129,19 @@ fi
+ 
+ ln -s ../erts-%I_VSN%/bin/epmd epmd
+ 
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/run_erl" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/to_erl" .
+-cp -p "$ERL_ROOT/erts-%I_VSN%/bin/start" .
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/run_erl" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/run_erl" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/to_erl" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/to_erl" .
++fi
++if [ -e "$ERL_ROOT/erts-%I_VSN%/bin/start" ]
++then
++    cp -p "$ERL_ROOT/erts-%I_VSN%/bin/start" .
++fi
++
+ sed -e "s;%EMU%;%EMULATOR%%EMULATOR_NUMBER%;" "$ERL_ROOT/erts-%I_VSN%/bin/start_erl.src" > start_erl
+ chmod 755 start_erl
+ 
+diff --git a/erts/lib_src/Makefile.in b/erts/lib_src/Makefile.in
+index 392d10f493..cf9e73b7be 100644
+--- a/erts/lib_src/Makefile.in
++++ b/erts/lib_src/Makefile.in
+@@ -39,6 +39,7 @@ INSTALL=@INSTALL@
+ INSTALL_DIR=@INSTALL_DIR@
+ INSTALL_DATA=@INSTALL_DATA@
+ INSTALL_PROGRAM=@INSTALL_PROGRAM@
++CROSS_COMPILING = @CROSS_COMPILING@
+ 
+ ERLANG_OSTYPE=@ERLANG_OSTYPE@
+ 
+@@ -313,7 +314,13 @@ YCF_SOURCE_DIR=$(ERL_TOP)/erts/lib_src/yielding_c_fun
+ 
+ include $(YCF_SOURCE_DIR)/main_target.mk
+ 
++ifeq ($(CROSS_COMPILING),no)
++# TODO: Move this to a proper flag in erts/configure.in
++#       (erl_xcomp_build_ycf=true|false)
+ $(OBJ_DIR)/MADE: $(YCF_EXECUTABLE) $(ETHREAD_LIB) $(ERTS_INTERNAL_LIBS)
++else
++$(OBJ_DIR)/MADE: $(ETHREAD_LIB) $(ERTS_INTERNAL_LIBS)
++endif
+ 	$(gen_verbose)
+ 	$(V_at)echo $? > $(OBJ_DIR)/MADE
+ 
+@@ -454,7 +461,11 @@ INTERNAL_RELEASE_LIBS= \
+ 
+ .PHONY: release_spec
+ release_spec: all
++ifeq ($(CROSS_COMPILING),no)
++# TODO: Move this to a proper flag in erts/configure.in
++#       (erl_xcomp_build_ycf=true|false)
+ 	$(INSTALL_PROGRAM) $(YCF_EXECUTABLE) "$(RELSYSDIR)/bin"
++endif
+ ifneq ($(strip $(RELEASE_INCLUDES)),)
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
+ 	$(INSTALL_DIR) "$(RELEASE_PATH)/usr/include"
+diff --git a/erts/lib_src/pthread/ethread.c b/erts/lib_src/pthread/ethread.c
+index da4f1af11d..efa50c53aa 100644
+--- a/erts/lib_src/pthread/ethread.c
++++ b/erts/lib_src/pthread/ethread.c
+@@ -149,6 +149,7 @@ ppc_init__(void)
+     /* If anything what so ever fails we assume no lwsync for safety */
+     ethr_runtime__.conf.have_lwsync = 0;
+ 
++#ifndef __rtems__
+     /*
+      * We perform the lwsync test (which might cause an illegal
+      * instruction signal) in a separate process in order to be
+@@ -180,6 +181,8 @@ ppc_init__(void)
+ 	    }
+ 	}
+     }
++#endif
++
+     return 0;
+ }
+ 
+diff --git a/lib/Makefile b/lib/Makefile
+index 1de8f2d04c..792607468a 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -66,7 +66,7 @@ endif
+ 
+ # Any applications listed in SKIP-APPLICATIONS should be skipped
+ SKIP_FILE := $(wildcard SKIP-APPLICATIONS)
+-SKIP_APPLICATIONS := $(if $(SKIP_FILE),$(shell cat $(SKIP_FILE)))
++SKIP_APPLICATIONS += $(if $(SKIP_FILE),$(shell cat $(SKIP_FILE)))
+ SUB_DIRECTORIES := $(filter-out $(SKIP_APPLICATIONS),$(SUB_DIRECTORIES))
+ 
+ # ----------------------------------------------------------------------
+diff --git a/lib/asn1/c_src/Makefile b/lib/asn1/c_src/Makefile
+index 82a6b6e87a..5fbba859c3 100644
+--- a/lib/asn1/c_src/Makefile
++++ b/lib/asn1/c_src/Makefile
+@@ -69,7 +69,9 @@ NIF_LIB_FILE = $(LIBDIR)/asn1rt_nif.lib
+ CLIB_FLAGS =
+ LN=cp
+ else
++ifneq ($(findstring rtems,$(TARGET)),rtems)
+ NIF_SHARED_OBJ_FILE = $(LIBDIR)/asn1rt_nif.so
++endif
+ NIF_LIB_FILE = $(LIBDIR)/asn1rt_nif.a
+ CLIB_FLAGS =
+ LN= ln -s
+@@ -136,7 +138,9 @@ include $(ERL_TOP)/make/otp_release_targets.mk
+ 
+ release_spec: opt
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/priv/lib"
++ifneq ($(findstring rtems,$(TARGET)),rtems)
+ 	$(INSTALL_PROGRAM) $(NIF_SHARED_OBJ_FILE) "$(RELSYSDIR)/priv/lib"
++endif
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/c_src"
+ 	$(INSTALL_DATA) *.c "$(RELSYSDIR)/c_src"
+ 
+diff --git a/lib/crypto/c_src/Makefile.in b/lib/crypto/c_src/Makefile.in
+index c67782e7bd..89a8595e45 100644
+--- a/lib/crypto/c_src/Makefile.in
++++ b/lib/crypto/c_src/Makefile.in
+@@ -121,10 +121,18 @@ CRYPTO_STATIC_OBJS = $(patsubst $(OBJDIR)/%$(TYPEMARKER).o,$(OBJDIR)/%_static$(T
+ 
+ NIF_ARCHIVE = $(LIBDIR)/crypto$(TYPEMARKER).a
+ 
++NIF_LIB =
++CALLBACK_LIB =
++ifneq ($(findstring rtems, $(TARGET)), rtems)
+ NIF_LIB = $(LIBDIR)/crypto$(TYPEMARKER).@DED_EXT@
+ CALLBACK_LIB = $(LIBDIR)/crypto_callback$(TYPEMARKER).@DED_EXT@
++endif
+ 
++ifneq ($(findstring rtems, $(TARGET)), rtems)
+ DISABLE_OTP_TEST_ENGINE = @DISABLE_OTP_TEST_ENGINE@
++else
++DISABLE_OTP_TEST_ENGINE = yes
++endif
+ ifeq ($(DISABLE_OTP_TEST_ENGINE),yes)
+ TEST_ENGINE_LIB =
+ TEST_ENGINE_OBJS =
+@@ -277,7 +285,9 @@ include $(ERL_TOP)/make/otp_release_targets.mk
+ 
+ release_spec: opt
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/priv/lib"
++ifneq ($(findstring rtems, $(TARGET)), rtems)
+ 	$(INSTALL_PROGRAM) $(NIF_LIB) "$(RELSYSDIR)/priv/lib"
++endif
+ ifeq ($(DYNAMIC_OR_WIN_CRYPTO_LIB),yes)
+ 	$(INSTALL_PROGRAM) $(CALLBACK_LIB) "$(RELSYSDIR)/priv/lib"
+ endif
+diff --git a/lib/crypto/configure b/lib/crypto/configure
+index 35b08dd781..987d8f40a9 100755
+--- a/lib/crypto/configure
++++ b/lib/crypto/configure
+@@ -765,6 +765,7 @@ enable_option_checking
+ enable_largefile
+ with_ssl
+ with_ssl_lib_subdir
++with_ssl_lib
+ with_ssl_incl
+ with_ssl_zlib
+ with_ssl_rpath
+@@ -1460,6 +1461,8 @@ Optional Packages:
+   --with-ssl-lib-subdir=RELATIVE_PATH
+                           specify extra OpenSSL lib sub-directory to search in
+                           (relative to base directory)
++  --with-ssl-lib=PATH     location of the library containing OpenSSL, if not
++                          standard
+   --with-ssl-incl=PATH    base location of OpenSSL include dir (if different
+                           than base location specified by --with-ssl=PATH)
+   --with-ssl-zlib=PATH    Path to static zlib library to link the crypto NIF
+@@ -5946,6 +5949,14 @@ fi
+  #default
+ 
+ 
++# Check whether --with-ssl-lib was given.
++if test ${with_ssl_lib+y}
++then :
++  withval=$with_ssl_lib;
++fi
++
++
++
+ # Check whether --with-ssl-incl was given.
+ if test ${with_ssl_incl+y}
+ then :
+@@ -6396,8 +6407,8 @@ fi
+ printf "%s\n" "$ac_cv_path_EGREP_TRADITIONAL" >&6; }
+  EGREP_TRADITIONAL=$ac_cv_path_EGREP_TRADITIONAL
+ 
+-case "$erl_xcomp_without_sysroot-$with_ssl" in #(
+-  yes-* | no-no) :
++case "$erl_xcomp_without_sysroot-$with_ssl-$with_ssl_lib" in #(
++  yes-* | no-no-*) :
+ 
+             SSL_APP=
+             CRYPTO_APP=
+@@ -6409,7 +6420,7 @@ case "$erl_xcomp_without_sysroot-$with_ssl" in #(
+                 echo "$skip" > $ERL_TOP/lib/$a/SKIP
+                 done
+          ;; #(
+-  no-yes | no-) :
++  no-yes- | no--) :
+ 
+             # We search for OpenSSL in the common OS standard locations.
+             SSL_APP=ssl
+@@ -6535,7 +6546,14 @@ rm -rf conftest*
+ 
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+-    if test $valid_include != yes
++    if test -f "$with_ssl_lib"
++then :
++
++              found_dynlib=no
++              found_static_lib=yes
++              static_ext=.a
++
++elif test $valid_include != yes
+ then :
+ 
+               # Not a valid include...
+@@ -6950,7 +6968,7 @@ esac
+ esac
+ fi
+          ;; #(
+-  *) :
++  *-*-) :
+ 
+             # Option given with PATH to package
+             if test ! -d "$with_ssl"
+@@ -7062,7 +7080,14 @@ rm -rf conftest*
+ 
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+-    if test $valid_include != yes
++    if test -f "$with_ssl_lib"
++then :
++
++              found_dynlib=no
++              found_static_lib=yes
++              static_ext=.a
++
++elif test $valid_include != yes
+ then :
+ 
+               # Not a valid include...
+@@ -7437,7 +7462,827 @@ else case e in #(
+                    ;;
+ esac
+ fi
+-         ;;
++         ;; #(
++  *) :
++
++            # Non-standard library specified by PATH
++            if test ! -f "$with_ssl_lib" ; then
++                as_fn_error $? "Invalid path to option --with-ssl-lib=PATH" "$LINENO" 5
++            fi
++
++            SSL_APP=ssl
++            CRYPTO_APP=crypto
++            SSH_APP=ssh
++
++            if test -d "$with_ssl_incl" ; then
++                if test ! -f "$with_ssl_incl/include/openssl/opensslv.h"; then
++                    as_fn_error $? "\"$with_ssl_incl/include/openssl/opensslv.h not found\"" "$LINENO" 5
++                fi
++                SSL_INCDIR="$with_ssl_incl"
++                SSL_INCLUDE="-I$SSL_INCDIR/include"
++
++    # Check for static and dynamic crypto library in the directory
++    # given as argument...
++    #
++    # Written as a macro in order to avoid writing the tests twice...
++    idir="$with_ssl_incl"
++    prfx=""
++    rdir="$with_ssl"
++    dir="$prfx$rdir"
++    static_crypto_lib_name=crypto
++    static_ssl_lib_name=ssl
++    static_extra_libs="$forced_static_zlib"
++    static_lib_dir=
++    dynamic_crypto_lib_name=crypto
++    dynamic_ssl_lib_name=ssl
++    dynamic_extra_libs="$forced_static_zlib"
++    dynamic_lib_dir=
++    dynamic_runtime_lib_dir=
++    found_static_lib=no
++    found_dynamic_lib=no
++
++    save_CPPFLAGS=$CPPFLAGS
++    CPPFLAGS="-I$idir/include"
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if OPENSSL_VERSION_NUMBER >= 0x0090803fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  valid_include=yes
++else $as_nop
++  valid_include=no
++fi
++rm -rf conftest*
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if OPENSSL_VERSION_MAJOR == 3
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  v3_include=yes
++else $as_nop
++  v3_include=no
++fi
++rm -rf conftest*
++
++
++
++    if test "x$DISABLE_OTP_TEST_ENGINE" = "xdefault"; then
++# Get default value for the --disable-otp-test-engine. Depends on cryptolib version
++          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if LIBRESSL_VERSION_NUMBER >= 0x3050000fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  DISABLE_OTP_TEST_ENGINE=yes
++else $as_nop
++  DISABLE_OTP_TEST_ENGINE=no
++fi
++rm -rf conftest*
++
++    fi
++
++    CPPFLAGS="$save_CPPFLAGS"
++
++    if test -f "$with_ssl_lib"
++then :
++
++              found_dynlib=no
++              found_static_lib=yes
++              static_ext=.a
++
++elif test $valid_include != yes
++then :
++
++              # Not a valid include...
++              static_crypto_lib_name=
++              static_ssl_lib_name=
++              static_extra_libs=
++              static_lib_dir=
++              dynamic_crypto_lib_name=
++              dynamic_ssl_lib_name=
++              dynamic_extra_libs=
++              dynamic_lib_dir=
++              dynamic_runtime_lib_dir=
++
++elif test "$host_os" = "win32"
++then :
++
++              # Windows...
++              if test -f "$dir/lib/VC/static/libcrypto${lib_bits}MD.lib"
++then :
++
++                        static_crypto_lib_name=libcrypto${lib_bits}MD
++                        static_ssl_lib_name="libssl${lib_bits}MD"
++                        static_extra_libs="$static_extra_libs -lCRYPT32 -lWS2_32"
++                        static_lib_dir="$dir/lib/VC/static"
++                        found_static_lib=yes
++
++fi
++              if test -f "$dir/lib/VC/libcrypto${lib_bits}MD.lib"
++then :
++
++                        dynamic_crypto_lib_name=libcrypto${lib_bits}MD
++                        dynamic_ssl_lib_name="libssl${lib_bits}MD"
++                        dynamic_runtime_lib_dir="$rdir/lib/VC"
++                        dynamic_lib_dir="$dir/lib/VC"
++                        found_dynamic_lib=yes
++
++fi
++
++else $as_nop
++
++              # Not windows...
++              case "$host_os" in #(
++  darwin*) :
++
++                          static_ext=.a
++                          dynamic_ext=.dylib
++                       ;; #(
++  *) :
++
++                          static_ext=.a
++                          dynamic_ext=.so
++                       ;;
++esac
++              for sdir in $search_subdirs; do
++                  if test -f "$dir/$sdir/lib$dynamic_crypto_lib_name$dynamic_ext"
++then :
++
++                            found_dynlib=yes
++
++else $as_nop
++
++                            found_dynlib=no
++                            case $host_os in #(
++  openbsd*) :
++
++                                        # libcrypto.so got a suffix on (at least some) openbsd.
++                                        # If we find libcrypto.so with suffix, we try to link
++                                        # to it using -lcrypto ...
++                                        for f in "$dir/$sdir/lib$dynamic_crypto_lib_name$dynamic_ext"*; do
++                                               if test -f "$f"
++then :
++  found_dynlib=yes; break
++fi
++                                        done
++                                     ;; #(
++  *) :
++     ;;
++esac
++
++fi
++                  if test $found_dynlib = yes
++then :
++
++                            # Found dynamic library; check if it links...
++                            dynamic_lib_dir="$dir/$sdir"
++                            dynamic_runtime_lib_dir="$rdir/$sdir"
++
++    test_cflags="-I$idir/include"
++    test_ldflags="-L$dynamic_lib_dir"
++    test_libs="-l$dynamic_crypto_lib_name $dynamic_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_dynamic_lib=yes
++
++else $as_nop
++
++	    found_dynamic_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++                            if test $found_dynamic_lib = no -a $static_zlib != no
++then :
++
++                                      # No, but linking with zlib as well might help...
++                                      dynamic_extra_libs="$dynamic_extra_libs $static_zlib"
++
++    test_cflags="-I$idir/include"
++    test_ldflags="-L$dynamic_lib_dir"
++    test_libs="-l$dynamic_crypto_lib_name $dynamic_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_dynamic_lib=yes
++
++else $as_nop
++
++	    found_dynamic_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++
++fi
++
++fi
++                  if test -f "$dir/$sdir/lib$static_crypto_lib_name$static_ext"
++then :
++
++                            # Found static library; check if it links...
++                            static_lib_dir="$dir/$sdir"
++
++    test_cflags="-I$idir/include"
++    test_ldflags=
++    test_libs="$dir/$sdir/lib$static_crypto_lib_name$static_ext $static_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_static_lib=yes
++
++else $as_nop
++
++	    found_static_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++                            if test $found_static_lib = no -a $static_zlib != no
++then :
++
++                                      # No, but inking with zlib as well might help...
++                                      static_extra_libs="$static_extra_libs $static_zlib"
++
++    test_cflags="-I$idir/include"
++    test_ldflags=
++    test_libs="$dir/$sdir/lib$static_crypto_lib_name$static_ext $static_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_static_lib=yes
++
++else $as_nop
++
++	    found_static_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++
++fi
++
++fi
++                  if test $found_static_lib = yes -o $found_dynamic_lib = yes
++then :
++  break
++fi
++              done
++
++fi
++
++              else
++                if test ! -f "$erl_xcomp_isysroot$rdir/include/openssl/opensslv.h"; then
++                    as_fn_error $? "\"$erl_xcomp_isysroot$rdir/include/openssl/opensslv.h not found\"" "$LINENO" 5
++                fi
++                SSL_INCDIR="$erl_xcomp_isysroot$rdir"
++                SSL_INCLUDE="-I$SSL_INCDIR/include"
++
++    # Check for static and dynamic crypto library in the directory
++    # given as argument...
++    #
++    # Written as a macro in order to avoid writing the tests twice...
++    idir="$SSL_INCDIR"
++    prfx="$erl_xcomp_sysroot"
++    rdir="$rdir"
++    dir="$prfx$rdir"
++    static_crypto_lib_name=crypto
++    static_ssl_lib_name=ssl
++    static_extra_libs="$forced_static_zlib"
++    static_lib_dir=
++    dynamic_crypto_lib_name=crypto
++    dynamic_ssl_lib_name=ssl
++    dynamic_extra_libs="$forced_static_zlib"
++    dynamic_lib_dir=
++    dynamic_runtime_lib_dir=
++    found_static_lib=no
++    found_dynamic_lib=no
++
++    save_CPPFLAGS=$CPPFLAGS
++    CPPFLAGS="-I$idir/include"
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if OPENSSL_VERSION_NUMBER >= 0x0090803fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  valid_include=yes
++else $as_nop
++  valid_include=no
++fi
++rm -rf conftest*
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if OPENSSL_VERSION_MAJOR == 3
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  v3_include=yes
++else $as_nop
++  v3_include=no
++fi
++rm -rf conftest*
++
++
++
++    if test "x$DISABLE_OTP_TEST_ENGINE" = "xdefault"; then
++# Get default value for the --disable-otp-test-engine. Depends on cryptolib version
++          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++#include <openssl/opensslv.h>
++#if LIBRESSL_VERSION_NUMBER >= 0x3050000fL
++yes
++#endif
++
++_ACEOF
++if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
++  $EGREP "^yes.?$" >/dev/null 2>&1
++then :
++  DISABLE_OTP_TEST_ENGINE=yes
++else $as_nop
++  DISABLE_OTP_TEST_ENGINE=no
++fi
++rm -rf conftest*
++
++    fi
++
++    CPPFLAGS="$save_CPPFLAGS"
++
++    if test -f "$with_ssl_lib"
++then :
++
++              found_dynlib=no
++              found_static_lib=yes
++              static_ext=.a
++
++elif test $valid_include != yes
++then :
++
++              # Not a valid include...
++              static_crypto_lib_name=
++              static_ssl_lib_name=
++              static_extra_libs=
++              static_lib_dir=
++              dynamic_crypto_lib_name=
++              dynamic_ssl_lib_name=
++              dynamic_extra_libs=
++              dynamic_lib_dir=
++              dynamic_runtime_lib_dir=
++
++elif test "$host_os" = "win32"
++then :
++
++              # Windows...
++              if test -f "$dir/lib/VC/static/libcrypto${lib_bits}MD.lib"
++then :
++
++                        static_crypto_lib_name=libcrypto${lib_bits}MD
++                        static_ssl_lib_name="libssl${lib_bits}MD"
++                        static_extra_libs="$static_extra_libs -lCRYPT32 -lWS2_32"
++                        static_lib_dir="$dir/lib/VC/static"
++                        found_static_lib=yes
++
++fi
++              if test -f "$dir/lib/VC/libcrypto${lib_bits}MD.lib"
++then :
++
++                        dynamic_crypto_lib_name=libcrypto${lib_bits}MD
++                        dynamic_ssl_lib_name="libssl${lib_bits}MD"
++                        dynamic_runtime_lib_dir="$rdir/lib/VC"
++                        dynamic_lib_dir="$dir/lib/VC"
++                        found_dynamic_lib=yes
++
++fi
++
++else $as_nop
++
++              # Not windows...
++              case "$host_os" in #(
++  darwin*) :
++
++                          static_ext=.a
++                          dynamic_ext=.dylib
++                       ;; #(
++  *) :
++
++                          static_ext=.a
++                          dynamic_ext=.so
++                       ;;
++esac
++              for sdir in $search_subdirs; do
++                  if test -f "$dir/$sdir/lib$dynamic_crypto_lib_name$dynamic_ext"
++then :
++
++                            found_dynlib=yes
++
++else $as_nop
++
++                            found_dynlib=no
++                            case $host_os in #(
++  openbsd*) :
++
++                                        # libcrypto.so got a suffix on (at least some) openbsd.
++                                        # If we find libcrypto.so with suffix, we try to link
++                                        # to it using -lcrypto ...
++                                        for f in "$dir/$sdir/lib$dynamic_crypto_lib_name$dynamic_ext"*; do
++                                               if test -f "$f"
++then :
++  found_dynlib=yes; break
++fi
++                                        done
++                                     ;; #(
++  *) :
++     ;;
++esac
++
++fi
++                  if test $found_dynlib = yes
++then :
++
++                            # Found dynamic library; check if it links...
++                            dynamic_lib_dir="$dir/$sdir"
++                            dynamic_runtime_lib_dir="$rdir/$sdir"
++
++    test_cflags="-I$idir/include"
++    test_ldflags="-L$dynamic_lib_dir"
++    test_libs="-l$dynamic_crypto_lib_name $dynamic_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_dynamic_lib=yes
++
++else $as_nop
++
++	    found_dynamic_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++                            if test $found_dynamic_lib = no -a $static_zlib != no
++then :
++
++                                      # No, but linking with zlib as well might help...
++                                      dynamic_extra_libs="$dynamic_extra_libs $static_zlib"
++
++    test_cflags="-I$idir/include"
++    test_ldflags="-L$dynamic_lib_dir"
++    test_libs="-l$dynamic_crypto_lib_name $dynamic_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_dynamic_lib=yes
++
++else $as_nop
++
++	    found_dynamic_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++
++fi
++
++fi
++                  if test -f "$dir/$sdir/lib$static_crypto_lib_name$static_ext"
++then :
++
++                            # Found static library; check if it links...
++                            static_lib_dir="$dir/$sdir"
++
++    test_cflags="-I$idir/include"
++    test_ldflags=
++    test_libs="$dir/$sdir/lib$static_crypto_lib_name$static_ext $static_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_static_lib=yes
++
++else $as_nop
++
++	    found_static_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++                            if test $found_static_lib = no -a $static_zlib != no
++then :
++
++                                      # No, but inking with zlib as well might help...
++                                      static_extra_libs="$static_extra_libs $static_zlib"
++
++    test_cflags="-I$idir/include"
++    test_ldflags=
++    test_libs="$dir/$sdir/lib$static_crypto_lib_name$static_ext $static_extra_libs"
++
++    saveCFLAGS="$CFLAGS"
++    saveLDFLAGS="$LDFLAGS"
++    saveLIBS="$LIBS"
++    CFLAGS="$DED_BASIC_CFLAGS $test_cflags"
++    LDFLAGS="$DED_LDFLAGS_CONFTEST $test_ldflags"
++    LIBS="$LIBS $test_libs"
++
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++		#include <stdio.h>
++		#include <openssl/hmac.h>
++
++int
++main (void)
++{
++
++		HMAC(0, 0, 0, 0, 0, 0, 0);
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++
++	    found_static_lib=yes
++
++else $as_nop
++
++	    found_static_lib=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++
++    CFLAGS="$saveCFLAGS"
++    LDFLAGS="$saveLDFLAGS"
++    LIBS="$saveLIBS"
++
++
++fi
++
++fi
++                  if test $found_static_lib = yes -o $found_dynamic_lib = yes
++then :
++  break
++fi
++              done
++
++fi
++
++            fi
++
++            libname_with_ext=${with_ssl_lib##*lib}
++            libname_without_ext=${libname_with_ext%%.*}
++
++            SSL_CRYPTO_LIBNAME=$static_crypto_lib_name
++            SSL_SSL_LIBNAME=$libname_without_ext
++            SSL_LIBDIR=$(dirname $with_ssl_lib)
++            SSL_EXTRA_LIBS="$static_extra_libs"
++            SSL_RUNTIME_LIBDIR=
++            SSL_DYNAMIC_ONLY=no
++
++            if test ! -f "${SSL_LIBDIR}/lib${SSL_SSL_LIBNAME}.a"; then
++              as_fn_error $? "--with-ssl-lib not supported with dynamic linking" "$LINENO" 5
++            fi
++
++                     ;;
+ esac
+ SSL_DED_LD_RUNTIME_LIBRARY_PATH=
+ ded_ld_rflg="$DED_LD_FLAG_RUNTIME_LIBRARY_PATH"
+diff --git a/lib/crypto/configure.ac b/lib/crypto/configure.ac
+index b5b5914247..0227d4f7f8 100644
+--- a/lib/crypto/configure.ac
++++ b/lib/crypto/configure.ac
+@@ -72,6 +72,8 @@ fi
+ dnl
+ dnl SSL, SSH and CRYPTO need the OpenSSL libraries
+ dnl
++dnl TODO: Update comments
++dnl
+ dnl Check flags --with-ssl, --without-ssl --with-ssl=PATH.
+ dnl If no option is given or --with-ssl is set without a path then we
+ dnl search for OpenSSL libraries and header files in the standard locations. 
+@@ -116,6 +118,10 @@ esac
+ ],
+ [with_ssl_lib_subdir=]) #default
+ 
++dnl TODO: Add checks regarding conflicts between --with-ssl and --with-ssl-lib
++AC_ARG_WITH(ssl-lib,
++AS_HELP_STRING([--with-ssl-lib=PATH], [location of the library containing OpenSSL, if not standard]))
++
+ AC_ARG_WITH(ssl-incl,
+ AS_HELP_STRING([--with-ssl-incl=PATH],
+ 	       [base location of OpenSSL include dir (if different than base location specified by --with-ssl=PATH)]),
+@@ -270,7 +276,13 @@ yes
+ 
+     CPPFLAGS="$save_CPPFLAGS"
+ 
+-    AS_IF([test $valid_include != yes],
++    AS_IF([test -f "$with_ssl_lib"],
++          [
++              found_dynlib=no
++              found_static_lib=yes
++              static_ext=.a
++          ],
++          [test $valid_include != yes],
+           [
+               # Not a valid include...
+               static_crypto_lib_name=
+@@ -462,8 +474,8 @@ case $enable_dynamic_ssl in
+ 	SSL_DYNAMIC_ONLY=no;;
+ esac
+ 
+-AS_CASE(["$erl_xcomp_without_sysroot-$with_ssl"],
+-        [yes-* | no-no],
++AS_CASE(["$erl_xcomp_without_sysroot-$with_ssl-$with_ssl_lib"],
++        [yes-* | no-no-*],
+         [
+             SSL_APP=
+             CRYPTO_APP=
+@@ -475,7 +487,7 @@ AS_CASE(["$erl_xcomp_without_sysroot-$with_ssl"],
+                 echo "$skip" > $ERL_TOP/lib/$a/SKIP
+                 done
+         ],
+-        [no-yes | no-],
++        [no-yes- | no--],
+         [
+             # We search for OpenSSL in the common OS standard locations.
+             SSL_APP=ssl
+@@ -586,6 +598,7 @@ AS_CASE(["$erl_xcomp_without_sysroot-$with_ssl"],
+                          done
+                   ])
+         ],
++        [*-*-],
+         [
+             # Option given with PATH to package
+             AS_IF([test ! -d "$with_ssl"],
+@@ -646,6 +659,48 @@ AS_CASE(["$erl_xcomp_without_sysroot-$with_ssl"],
+                   [
+                       SSL_RUNTIME_LIBDIR="$SSL_LIBDIR"
+                   ])
++        ],
++        [
++            # Non-standard library specified by PATH
++            if test ! -f "$with_ssl_lib" ; then
++                AC_MSG_ERROR(Invalid path to option --with-ssl-lib=PATH)
++            fi
++
++            SSL_APP=ssl
++            CRYPTO_APP=crypto
++            SSH_APP=ssh
++
++            if test -d "$with_ssl_incl" ; then
++                if test ! -f "$with_ssl_incl/include/openssl/opensslv.h"; then
++                    AC_MSG_ERROR("$with_ssl_incl/include/openssl/opensslv.h not found")
++                fi
++                SSL_INCDIR="$with_ssl_incl"
++                SSL_INCLUDE="-I$SSL_INCDIR/include"
++                ERL_CRYPTO_CHECK_LIB(["$with_ssl_incl"], [""], ["$with_ssl"])
++              else
++                if test ! -f "$erl_xcomp_isysroot$rdir/include/openssl/opensslv.h"; then
++                    AC_MSG_ERROR("$erl_xcomp_isysroot$rdir/include/openssl/opensslv.h not found")
++                fi
++                SSL_INCDIR="$erl_xcomp_isysroot$rdir"
++                SSL_INCLUDE="-I$SSL_INCDIR/include"
++                ERL_CRYPTO_CHECK_LIB(["$SSL_INCDIR"], ["$erl_xcomp_sysroot"], ["$rdir"])
++            fi
++
++            libname_with_ext=${with_ssl_lib##*lib}
++            libname_without_ext=${libname_with_ext%%.*}
++
++            SSL_CRYPTO_LIBNAME=$static_crypto_lib_name
++            SSL_SSL_LIBNAME=$libname_without_ext
++            SSL_LIBDIR=$(dirname $with_ssl_lib)
++            SSL_EXTRA_LIBS="$static_extra_libs"
++            SSL_RUNTIME_LIBDIR=
++            SSL_DYNAMIC_ONLY=no
++
++            if test ! -f "${SSL_LIBDIR}/lib${SSL_SSL_LIBNAME}.a"; then
++              AC_MSG_ERROR(--with-ssl-lib not supported with dynamic linking)
++            fi
++
++            dnl TODO: Add a check for the lib actually having OpenSSL symbols ?
+         ])dnl AS_CASE
+ 
+ SSL_DED_LD_RUNTIME_LIBRARY_PATH=
+diff --git a/lib/erl_interface/src/connect/ei_connect.c b/lib/erl_interface/src/connect/ei_connect.c
+index f95895a7e4..61d8427559 100644
+--- a/lib/erl_interface/src/connect/ei_connect.c
++++ b/lib/erl_interface/src/connect/ei_connect.c
+@@ -2023,7 +2023,7 @@ static unsigned int gen_challenge(void)
+     uname(&s.name);
+     s.cpu  = clock();
+     s.pid  = getpid();
+-#if defined(__ANDROID__) || defined(__HAIKU__)
++#if defined(__ANDROID__) || defined(__HAIKU__) || defined(__rtems__)
+     s.hid  = 0;
+ #else
+     s.hid  = gethostid();
+diff --git a/lib/erl_interface/src/connect/ei_resolve.c b/lib/erl_interface/src/connect/ei_resolve.c
+index c3ac6023f2..bc37a7a227 100644
+--- a/lib/erl_interface/src/connect/ei_resolve.c
++++ b/lib/erl_interface/src/connect/ei_resolve.c
+@@ -398,7 +398,7 @@ struct hostent *ei_gethostbyaddr_r(const char *addr,
+   return gethostbyaddr(addr, length, type);
+ #elif !defined(HAVE_GETHOSTBYNAME_R)
+   return my_gethostbyaddr_r(addr,length,type,hostp,buffer,buflen,h_errnop);
+-#elif (defined(__GLIBC__) || defined(__linux__) || (defined(__FreeBSD_version) && (__FreeBSD_version >= 602000)) || defined(__DragonFly__))
++#elif (defined(__GLIBC__) || defined(__linux__) || (defined(__FreeBSD_version) && (__FreeBSD_version >= 602000)) || defined(__DragonFly__)) || defined(__rtems__)
+   struct hostent *result;
+ 
+   gethostbyaddr_r(addr, length, type, hostp, buffer, buflen, &result,
+@@ -421,7 +421,7 @@ struct hostent *ei_gethostbyname_r(const char *name,
+   return gethostbyname(name);
+ #elif !defined(HAVE_GETHOSTBYNAME_R)
+   return my_gethostbyname_r(name,hostp,buffer,buflen,h_errnop);
+-#elif (defined(__GLIBC__) || defined(__linux__) || (defined(__FreeBSD_version) && (__FreeBSD_version >= 602000)) || defined(__DragonFly__) || defined(__ANDROID__))
++#elif (defined(__GLIBC__) || defined(__linux__) || (defined(__FreeBSD_version) && (__FreeBSD_version >= 602000)) || defined(__DragonFly__) || defined(__ANDROID__)) || defined(__rtems__)
+   struct hostent *result;
+   int err;
+ 
+diff --git a/lib/kernel/src/erl_distribution.erl b/lib/kernel/src/erl_distribution.erl
+index 914464bb55..4c364af186 100644
+--- a/lib/kernel/src/erl_distribution.erl
++++ b/lib/kernel/src/erl_distribution.erl
+@@ -72,7 +72,7 @@ start_link(Opts) ->
+     supervisor:start_link({local,net_sup}, ?MODULE, [Opts]).
+ 
+ init(NetArgs) ->
+-    Epmd = 
++    Epmd =
+ 	case init:get_argument(no_epmd) of
+ 	    {ok, [[]]} ->
+ 		[];
+@@ -85,6 +85,13 @@ init(NetArgs) ->
+                    type => worker,
+                    modules => [EpmdMod]}]
+ 	end,
++    EpmdSrv = case init:get_argument(internal_epmd) of
++        {ok, [[EpmdSrvMod]]} ->
++            Esm = list_to_atom(EpmdSrvMod),
++            Esm:get_childspecs();
++        _ ->
++            []
++    end,
+     Auth = #{id => auth,
+              start => {auth,start_link,[]},
+              restart => permanent,
+@@ -101,7 +108,7 @@ init(NetArgs) ->
+     SupFlags = #{strategy => one_for_all,
+                  intensity => 0,
+                  period => 1},
+-    {ok, {SupFlags, EarlySpecs ++ Epmd ++ [Auth,Kernel]}}.
++    {ok, {SupFlags, EarlySpecs ++ EpmdSrv ++ Epmd ++ [Auth,Kernel]}}.
+ 
+ do_start_link([{Arg,Flag}|T]) ->
+     case init:get_argument(Arg) of
+diff --git a/lib/runtime_tools/c_src/Makefile.in b/lib/runtime_tools/c_src/Makefile.in
+index c6f98181be..616dd7d6a5 100644
+--- a/lib/runtime_tools/c_src/Makefile.in
++++ b/lib/runtime_tools/c_src/Makefile.in
+@@ -39,7 +39,11 @@ SHELL = /bin/sh
+ LIBS = $(DED_LIBS) @LIBS@
+ LDFLAGS += $(DED_LDFLAGS)
+ 
++ifeq ($(findstring rtems,$(TARGET)),rtems)
++TRACE_LIBNAME =
++else
+ TRACE_LIBNAME = dyntrace trace_file_drv trace_ip_drv
++endif
+ 
+ SYSINCLUDE = $(DED_SYS_INCLUDE)
+ 
+@@ -108,9 +112,13 @@ docs:
+ # ----------------------------------------------------
+ include $(ERL_TOP)/make/otp_release_targets.mk
+ 
++ifeq ($(findstring rtems,$(TARGET)),rtems)
++release_spec:
++else
+ release_spec: opt
+ 	$(INSTALL_DIR) "$(RELSYSDIR)/priv/lib"
+ 	$(INSTALL_PROGRAM) $(TRACE_LIBS) "$(RELSYSDIR)/priv/lib"
++endif
+ 
+ release_docs_spec:
+ 
+diff --git a/make/configure b/make/configure
+index 11ebf99c84..6ad4b6c208 100755
+--- a/make/configure
++++ b/make/configure
+@@ -774,6 +774,7 @@ with_javac
+ enable_megaco_flex_scanner_lineno
+ enable_megaco_reentrant_flex_scanner
+ with_ssl
++with_ssl_lib
+ with_ssl_incl
+ with_ssl_zlib
+ with_ssl_lib_subdir
+@@ -1521,6 +1522,8 @@ Optional Packages:
+   --with-ssl=PATH         base location of OpenSSL include and lib directories
+   --with-ssl              use SSL (default)
+   --without-ssl           don't use SSL
++  --with-ssl-lib=PATH     location of the library containing OpenSSL, if not
++                          standard
+   --with-ssl-incl=PATH    base location of OpenSSL include directory (if
+                           different than base location specified by
+                           --with-ssl=PATH)
+@@ -5702,6 +5705,14 @@ fi
+ 
+ 
+ 
++# Check whether --with-ssl-lib was given.
++if test ${with_ssl_lib+y}
++then :
++  withval=$with_ssl_lib;
++fi
++
++
++
+ # Check whether --with-ssl-incl was given.
+ if test ${with_ssl_incl+y}
+ then :
+diff --git a/make/configure.ac b/make/configure.ac
+index f2f423b09f..219a1c2c5d 100644
+--- a/make/configure.ac
++++ b/make/configure.ac
+@@ -254,6 +254,10 @@ AS_HELP_STRING([--with-ssl=PATH], [base location of OpenSSL include and lib dire
+ AS_HELP_STRING([--with-ssl], [use SSL (default)])
+ AS_HELP_STRING([--without-ssl], [don't use SSL]))
+ 
++AC_ARG_WITH(ssl-lib,
++AS_HELP_STRING([--with-ssl-lib=PATH],
++               [location of the library containing OpenSSL, if not standard]))
++
+ AC_ARG_WITH(ssl-incl,
+ AS_HELP_STRING([--with-ssl-incl=PATH],
+ 	       [base location of OpenSSL include directory (if different than base location specified by --with-ssl=PATH)]))

--- a/grisp/default/27.3/build/patches/00100-rtems.patch
+++ b/grisp/default/27.3/build/patches/00100-rtems.patch
@@ -146,10 +146,10 @@ index ba5ba255d4..93e8fe08c9 100644
  
  int erts_sys_prepare_crash_dump(int secs)
 diff --git a/erts/etc/common/Makefile.in b/erts/etc/common/Makefile.in
-index 42af9c87dc..dfc2ca3292 100644
+index 42af9c87dc..919d32869d 100644
 --- a/erts/etc/common/Makefile.in
 +++ b/erts/etc/common/Makefile.in
-@@ -181,6 +181,26 @@ endif
+@@ -183,6 +183,26 @@ endif
  PORT_ENTRY_POINT=erl_port_entry
  ENTRY_LDFLAGS=-entry:$(PORT_ENTRY_POINT)
  
@@ -176,15 +176,15 @@ index 42af9c87dc..dfc2ca3292 100644
  else
  ENTRY_LDFLAGS=
  ENTRY_OBJ=
-@@ -214,6 +234,7 @@ INSTALL_PROGS =              \
+@@ -216,6 +236,7 @@ INSTALL_PROGS =              \
  	$(BINDIR)/$(ERLEXEC) \
  	$(INSTALL_EMBEDDED_PROGS)
  endif
 +endif
- 
- CREATE_DIRS=$(OBJDIR) $(BINDIR)
- 
-@@ -488,11 +509,13 @@ $(BINDIR)/typer@EXEEXT@: $(OBJDIR)/typer.o $(ERTS_LIB)
+
+ -include ../unix/gdb-tools/jit-reader.mk
+
+@@ -494,11 +515,13 @@ $(BINDIR)/typer@EXEEXT@: $(OBJDIR)/typer.o $(ERTS_LIB)
  $(OBJDIR)/typer.o: typer.c $(RC_GENERATED)
  	$(V_CC) $(CFLAGS) -o $@ -c typer.c
  

--- a/grisp/default/27.3/build/patches/00300-drivers-nifs.patch.mustache
+++ b/grisp/default/27.3/build/patches/00300-drivers-nifs.patch.mustache
@@ -1,0 +1,32 @@
+{{#erts_emulator_makefile_in}}
+diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+index 2f8eee6eed..b83fb5092d 100644
+--- a/erts/emulator/Makefile.in
++++ b/erts/emulator/Makefile.in
+@@ -1148,6 +1148,{{nif_lines}} @@ NIF_OBJS = \
+ 	$(OBJDIR)/zlib_nif.o \
+ 	$(ESOCK_NIF_OBJS)
+ 
++ifeq ($(findstring rtems,$(TARGET)),rtems)
+{{#nifs}}
++	NIF_OBJS += $(OBJDIR)/{{name}}.o
+{{/nifs}}
++endif
++
+ ifeq ($(TARGET),win32)
+ DRV_OBJS = \
+ 	$(OBJDIR)/registry_drv.o \
+@@ -1182,6 +1186,10 @@ DRV_OBJS = \
+ 	$(OBJDIR)/ram_file_drv.o
+ endif
+ 
++ifeq ($(findstring rtems,$(TARGET)),rtems)
+{{#drivers}}
++	DRV_OBJS += $(OBJDIR)/{{name}}.o
+{{/drivers}}
++endif
++
+ ifneq ($(STATIC_NIFS),no)
+ STATIC_NIF_LIBS = $(STATIC_NIFS)
+ DEPLIBS += $(STATIC_NIF_LIBS)
+{{/erts_emulator_makefile_in}}


### PR DESCRIPTION
This PR fixes #162

How to test:

1.  Create a `grisp` project with `OTP ^27.3`:
```
rebar3 grisp configure -i false --otp_version="=27.3" --dest="_deploy"
```
2. Create the destination folder:
```
mkdir robot/_deploy
```
3. Add the path of `toolchain` in the build section in` rebar3.config`
4. Clone this branch in _checkouts
5. Run `rebar3 grisp build --tar`