### PR TITLE
Add fallback step if OTP version exists 

### DIFF
--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -105,6 +105,7 @@ jobs:
         rebar3: ['3']
     outputs:
       artifacts: ${{ steps.matrix-def.outputs.otp-version }}
+      upload-output: ${{ steps.set-upload-output.outputs.upload-output }}
     steps:
       - uses: erlef/setup-beam@v1
         with:
@@ -161,9 +162,13 @@ jobs:
           aws s3 cp --acl public-read --storage-class INTELLIGENT_TIERING \
           ${{env.pkg_name}} \
           s3://grisp/platforms/grisp2/otp/
+      - name: Set S3 upload output
+        if: ${{ steps.upload-s3.outcome == 'success' }}
+        run: echo "upload-output=true" >> $GITHUB_OUTPUT
+        id: set-upload-output
   slack-message:
     runs-on: ubuntu-latest
-    if: ${{ steps.upload-s3.outcome == 'success' }}
+    if: ${{ needs.upload_artifacts.outputs.upload-output == 'true' }}
     needs: [define-matrix, otp-gen-matrix, upload_artifacts]
     steps:
     - name: Notify Slack channels through Zapier Webhook

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p ${HOME}/.config/rebar3/
           echo "{plugins, [rebar3_hex,rebar3_grisp]}." > ${HOME}/.config/rebar3/rebar.config
-          rebar3
+          rebar3 update
       - name: Generate Dummy Project
         run: |
           rebar3 grisp configure -i false --otp_version="=${{matrix.otp}}" --dest="_deploy"
@@ -140,6 +140,7 @@ jobs:
       - name: Download Package Artifact
         id: artifact-download
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: ${{env.pkg_name}}
       - name: Download from S3 if artifact not found

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -126,7 +126,7 @@ jobs:
           s/{deps, \[\n[[:space:]]*grisp\n\]}.*/{deps, [${{matrix.deps}}]}./
           }' robot/rebar.config
           cat robot/rebar.config
-      - name: Get Package Name
+      - name: Build Package
         id: deploy
         working-directory: robot
         run: |
@@ -141,7 +141,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{env.pkg_name}}
+      - name: Download from S3 if artifact not found
+        id: download-s3
+        if: steps.artifact-download.outcome == 'failure'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.GRISP_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          aws s3 cp s3://grisp/platforms/grisp2/otp/${{env.pkg_name}} .
       - name: Upload to S3
+        id: upload-s3
         if: ${{ steps.artifact-download.outcome == 'success' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GRISP_S3_ACCESS_KEY_ID }}
@@ -153,6 +163,7 @@ jobs:
           s3://grisp/platforms/grisp2/otp/
   slack-message:
     runs-on: ubuntu-latest
+    if: ${{ steps.upload-s3.outcome == 'success' }}
     needs: [define-matrix, otp-gen-matrix, upload_artifacts]
     steps:
     - name: Notify Slack channels through Zapier Webhook


### PR DESCRIPTION
Some OTP artifacts were uploaded manually to S3, the CI failed at the “Download Package Artifact” step, which uses actions/download-artifact@v4. On this PR a fallback step is added to prevent the error.