### PR TITLE
fix broken source links

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,7 @@
 {project_plugins, [erlfmt, rebar3_ex_doc]}.
 
 {ex_doc, [
+    {prefix_ref_vsn_with_v, false},
     {extras, [
           {"CHANGELOG.md", #{title => "Changelog"}},
           {"README.md", #{title => "Overview"}},


### PR DESCRIPTION
**Problem**: The published documentation for GRiSP versions `2.8.0` and `2.9.0` on hexdocs.pm has broken source links, preventing users from navigating to the correct source code references.

**Solution**: Republish the documentation for both versions using `rebar3 hex publish docs` to fix the broken source links. Fix the problem with `{prefix_ref_vsn_with_v, false}` in `rebar.config` since we don't use the `v` prefix for git tags.