### PR TITLE
Remove fromJson usage + fix zizmor

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ gh api \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   /repos/grisp/grisp/dispatches \
   -f "event_type=new-otp-release" \
-  -F "client_payload[otp]=\\\"27.1.2\\\"" \
+  -F "client_payload[otp]=28.4.1" \
   -F "client_payload[unit]=false" \
   -F "client_payload[integration]=true"
 ```

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "$tag" > last_seen_ver.txt
           echo "LAST_OTP=$(cat last_seen_ver.txt)" >> $GITHUB_ENV
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         if: steps.get-version.outputs.should_continue == 'true'
         id: version-cache
         env:

--- a/.github/workflows/check_otp_rel.yaml
+++ b/.github/workflows/check_otp_rel.yaml
@@ -69,4 +69,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             https://api.github.com/repos/grisp/grisp/dispatches \
-            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"\\\\\\\"${OTP}\\\\\\\"\",\"unit\":false,\"integration\":true}}"
+            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"${OTP}\",\"unit\":false,\"integration\":true}}"

--- a/.github/workflows/check_otp_rel_candidate.yaml
+++ b/.github/workflows/check_otp_rel_candidate.yaml
@@ -66,6 +66,6 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             https://api.github.com/repos/grisp/grisp/dispatches \
-            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"\\\\\\\"${OTP}\\\\\\\"\",\"unit\":false,\"integration\":true}}"
+            -d "{\"event_type\":\"new-otp-release\",\"client_payload\":{\"otp\":\"${OTP}\",\"unit\":false,\"integration\":true}}"
         env:
           MATRIX_RELEASE_TAG_NAME: ${{ matrix.release.tag_name }}

--- a/.github/workflows/check_otp_rel_candidate.yaml
+++ b/.github/workflows/check_otp_rel_candidate.yaml
@@ -39,7 +39,7 @@ jobs:
         env:
           MATRIX_RELEASE_TAG_NAME: ${{ matrix.release.tag_name }}
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         id: version-cache
         env:
           cache-name: cached-version

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -39,7 +39,7 @@ jobs:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         env:
           cache-name: rebar3
         with:

--- a/.github/workflows/on_grisp_release.yaml
+++ b/.github/workflows/on_grisp_release.yaml
@@ -34,7 +34,6 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           https://api.github.com/repos/grisp/grisp/dispatches \
-           -d "{\"event_type\":\"grisp-release\",\"client_payload\":{\"otp\":\"\\\\\\\"${OTP_VER}\\\\\\\"\",\"unit\":false,\"integration\":true}}"
+           -d "{\"event_type\":\"grisp-release\",\"client_payload\":{\"otp\":\"${OTP_VER}\",\"unit\":false,\"integration\":true}}"
           done
-
 

--- a/.github/workflows/otp_pkg.yaml
+++ b/.github/workflows/otp_pkg.yaml
@@ -35,7 +35,7 @@ jobs:
         ImageOS: 'ubuntu22'
     strategy:
       matrix:
-        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
+        otp: ["${{ needs.define-matrix.outputs.otp-version }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
       fail-fast: false
@@ -127,7 +127,7 @@ jobs:
       actions: read
     strategy:
       matrix:
-        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
+        otp: ["${{ needs.define-matrix.outputs.otp-version }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3']
     outputs:

--- a/.github/workflows/otp_pkg_on_grisp_release.yaml
+++ b/.github/workflows/otp_pkg_on_grisp_release.yaml
@@ -35,7 +35,7 @@ jobs:
         ImageOS: 'ubuntu22'
     strategy:
       matrix:
-        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
+        otp: ["${{ needs.define-matrix.outputs.otp-version }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3.24.0']
       fail-fast: false
@@ -127,7 +127,7 @@ jobs:
       actions: read
     strategy:
       matrix:
-        otp: ["${{ fromJson(needs.define-matrix.outputs.otp-version) }}"]
+        otp: ["${{ needs.define-matrix.outputs.otp-version }}"]
         deps: ['grisp', 'grisp, grisp_cryptoauth']
         rebar3: ['3.24.0']
     outputs:
@@ -196,4 +196,3 @@ jobs:
         if: ${{ steps.upload-s3.outcome == 'success' }}
         run: echo "upload-output=true" >> $GITHUB_OUTPUT
         id: set-upload-output
-

--- a/.github/workflows/otp_pkg_on_grisp_release.yaml
+++ b/.github/workflows/otp_pkg_on_grisp_release.yaml
@@ -17,7 +17,10 @@ jobs:
       - name: Matrix Definition
         id: matrix-def
         run: |
-           echo "otp-version=${GITHUB_EVENT_CLIENT_PAYLOAD_OTP}" >> "$GITHUB_OUTPUT"
+          OTP_VERSION="${GITHUB_EVENT_CLIENT_PAYLOAD_OTP}"
+          OTP_VERSION="${OTP_VERSION#\"}"
+          OTP_VERSION="${OTP_VERSION%\"}"
+          echo "otp-version=${OTP_VERSION}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_EVENT_CLIENT_PAYLOAD_OTP: ${{ github.event.client_payload.otp }}
   otp-gen-matrix:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["master"]
+    branches: ["**"]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
- Recent changes made `fromJson` Obsolete so we need to remove it
- We do not need nested escape sequences anymore
- Simpler GH call for manual trigger of the repository dispatch event
- Fix zizmor trigger to align with rule 


The new workflow is running fine 

https://github.com/grisp/trigger_test/actions/runs/23186679597